### PR TITLE
GRAILSPLUGINS-2505

### DIFF
--- a/SpringSecurityCoreGrailsPlugin.groovy
+++ b/SpringSecurityCoreGrailsPlugin.groovy
@@ -173,6 +173,7 @@ class SpringSecurityCoreGrailsPlugin {
 		}
 
 		println '\nConfiguring Spring Security ...'
+		SpringSecurityUtils.reset()
 
 		createRefList.delegate = delegate
 

--- a/src/java/org/codehaus/groovy/grails/plugins/springsecurity/SpringSecurityUtils.java
+++ b/src/java/org/codehaus/groovy/grails/plugins/springsecurity/SpringSecurityUtils.java
@@ -119,6 +119,12 @@ public final class SpringSecurityUtils {
 		// static only
 	}
 
+	public static void reset()
+	{
+		ORDERED_FILTERS.clear();
+		CONFIGURED_ORDERED_FILTERS.clear();
+	}
+	
 	/**
 	 * Extract the role names from authorities.
 	 * @param authorities  the authorities (a collection or array of {@link GrantedAuthority}).


### PR DESCRIPTION
Reset static state when initializing plugin. This is so that it can be initialized multiple times, which happens if
both integration and functional test phases are run.
