### PR TITLE
Fix serialization problem with GrailsUser

### DIFF
--- a/src/groovy/org/codehaus/groovy/grails/plugins/springsecurity/GrailsUser.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/springsecurity/GrailsUser.groovy
@@ -25,6 +25,8 @@ import org.springframework.security.core.userdetails.User
  */
 class GrailsUser extends User {
 
+	static final long serialVersionUID = 1L
+
 	private final Object _id
 
 	GrailsUser(String username, String password, boolean enabled, boolean accountNonExpired,


### PR DESCRIPTION
Hi,

I run multiple tomcat instances for a single site.  Once I upgraded Acegi to spring-security I found that putting new application releases live (done by removing a tomcat from the cluster, upgrading and then putting it back) was causing serialization failures in the migrated sessions and hence logging out all users.

This patch fixes the issue for me by setting a consistent serialVersionUID in the GrailsUser class.

Simon
