### PR TITLE
1.2.8 - Updates to s2-quickstart

### DIFF
--- a/SpringSecurityCoreGrailsPlugin.groovy
+++ b/SpringSecurityCoreGrailsPlugin.groovy
@@ -111,7 +111,7 @@ import org.codehaus.groovy.grails.plugins.springsecurity.WebExpressionVoter
  */
 class SpringSecurityCoreGrailsPlugin {
 
-	String version = '1.2.7'
+	String version = '1.2.8'
 	String grailsVersion = '1.2.2 > *'
 	List observe = ['controllers']
 	List loadAfter = ['controllers', 'services', 'hibernate']

--- a/scripts/S2Quickstart.groovy
+++ b/scripts/S2Quickstart.groovy
@@ -26,7 +26,7 @@ Creates a user and role class (and optionally a requestmap class) in the specifi
 Example: grails s2-quickstart com.yourapp User Role
 Example: grails s2-quickstart com.yourapp Person Authority Requestmap
 
-Create login and logout controllers
+Create login and logout controllers (useful with LDAP, Mock, Shibboleth, etc...)
 
 Example: grails s2-quickstart --controllers-only
 """

--- a/src/docs/ref/Scripts/s2-quickstart.gdoc
+++ b/src/docs/ref/Scripts/s2-quickstart.gdoc
@@ -2,10 +2,13 @@ h1. s2-quickstart
 
 h2. Purpose
 
-Creates a user and role class (and optionally a requestmap class) in the specified package. The general format is:
+Creates login and logout crontrollers, views and a user and role class (and optionally a requestmap class) in the specified package. The general format is:
+Alternativly, creates only login and logout controllers and their associated views.
 
 bc.
 grails s2-quickstart DOMAIN_CLASS_PACKAGE USER_CLASS_NAME ROLE_CLASS_NAME \[REQUESTMAP_CLASS_NAME\]
+or
+grails s2-quickstart --controllers-only
 
 h2. Examples
 
@@ -15,7 +18,12 @@ grails s2-quickstart com.yourapp User Role
 bc.
 grails s2-quickstart com.yourapp Person Authority Requestmap
 
+bc.
+grails s2-quickstart --controllers-only
+
 h2. Description
+
+Standard format (DOMAIN_CLASS_PACKAGE USER_CLASS_NAME ROLE_CLASS_NAME \[REQUESTMAP_CLASS_NAME\])
 
 * creates domain classes in @grails-app/domain@
 * creates example GSPs and controllers:
@@ -23,3 +31,11 @@ h2. Description
 ** @grails-app/views/login/denied.gsp@ - shows a 403 error page
 ** @grails-app/controllers/LoginController.groovy@ - manages login workflow
 ** @grails-app/controllers/LogoutController.groovy@ - logs users out of the application
+
+Controllers only format, useful for plugins that provide their own useri details classes. (LDAP, Mock, Shibboleth, etc...)
+* creates example GSPs and controllers:
+** @grails-app/views/login/auth.gsp@ - shows a standard username/password login page
+** @grails-app/views/login/denied.gsp@ - shows a 403 error page
+** @grails-app/controllers/LoginController.groovy@ - manages login workflow
+** @grails-app/controllers/LogoutController.groovy@ - logs users out of the application
+


### PR DESCRIPTION
I often use spring-security plugins that don't use domain classes, so I've added support to the s2-quickstart script to allow creation of controllers/view, but no domain classes.

The most obvious use for this is in the LDAP plugin, but I also use it in my own plugins (Mock and Shibboleth).
