### PR TITLE
Updated LoginController template to include an import of SpringSecurityS...

### DIFF
--- a/src/templates/LoginController.groovy.template
+++ b/src/templates/LoginController.groovy.template
@@ -12,6 +12,8 @@ import org.springframework.security.core.context.SecurityContextHolder as SCH
 import org.springframework.security.web.WebAttributes
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
+import grails.plugins.springsecurity.SpringSecurityService
+
 class LoginController {
 
 	/**


### PR DESCRIPTION
In grails-2.3.0.RC1, LoginController template fails with an error (as seen in the image below) "Cannot call isLoggedIn on null object." I fixed this by explicitly importing SpringSecurityService. 

PS: Also to let you know, the "@Secured(...)" annotation needs to be explicitly imported for it to work with grails 2.3, if you would like to update the tutorials section of the documentation to include this.

![screen shot 2013-08-21 at 2 10 25 pm](https://f.cloud.github.com/assets/340027/1003408/09770a94-0a8d-11e3-84eb-8f4c74366d9e.png)
