### PR TITLE
If client pass 'nopage' in HTTP header, it indicates they expect 401 ins...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ grails-spring-security-core-*.zip.sha1
 plugin.xml
 .settings
 web-app
+
+.idea/
+target/
+*.iml

--- a/SpringSecurityCoreGrailsPlugin.groovy
+++ b/SpringSecurityCoreGrailsPlugin.groovy
@@ -129,7 +129,7 @@ import org.springframework.web.filter.DelegatingFilterProxy
  */
 class SpringSecurityCoreGrailsPlugin {
 
-	String version = '2.0-RC2'
+	String version = '2.0.0.1-RC2'
 	String grailsVersion = '2.0.0 > *'
 	List observe = ['controllers']
 	List loadAfter = ['controllers', 'services', 'hibernate']

--- a/src/java/grails/plugin/springsecurity/web/authentication/AjaxAwareAuthenticationEntryPoint.java
+++ b/src/java/grails/plugin/springsecurity/web/authentication/AjaxAwareAuthenticationEntryPoint.java
@@ -16,12 +16,16 @@ package grails.plugin.springsecurity.web.authentication;
 
 import grails.plugin.springsecurity.SpringSecurityUtils;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.util.Assert;
+
+import java.io.IOException;
 
 /**
  * @author <a href='mailto:burt@burtbeckwith.com'>Burt Beckwith</a>
@@ -57,4 +61,13 @@ public class AjaxAwareAuthenticationEntryPoint extends LoginUrlAuthenticationEnt
 		Assert.isTrue(url == null || url.startsWith("/"), "ajaxLoginFormUrl must begin with '/'");
 		ajaxLoginFormUrl = url;
 	}
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        if(StringUtils.equalsIgnoreCase(request.getHeader("nopage"), "true")) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: The requested URL is protected");
+            return;
+        }
+        super.commence(request, response, authException);
+    }
 }


### PR DESCRIPTION
Hi,
If the grails app with spring security is being used by multiple clients. One client use login form. And another clients probably don't use login form (e.g. angularJS)

in this case, I want to differentiate the call. For angularJS, it will pass HTTP header (or other indicator) to indicate that it's expecting 401 instead of login form. So, I propose this modification in AjaxAwareAuthEntryPoint

Btw, I don't have full knowledge of spring security. if you know better solution, please kindly share with me.

Thanks :)
