### PR TITLE
deal with null currentConfig

### DIFF
--- a/src/java/grails/plugin/springsecurity/SpringSecurityUtils.java
+++ b/src/java/grails/plugin/springsecurity/SpringSecurityUtils.java
@@ -669,10 +669,16 @@ public final class SpringSecurityUtils {
 	private static ConfigObject mergeConfig(final ConfigObject currentConfig, final ConfigObject secondary) {
 		ConfigObject config = new ConfigObject();
 		if (secondary == null) {
-			config.putAll(currentConfig);
+			if(currentConfig != null) {
+				config.putAll(currentConfig);
+			}
 		}
 		else {
-			config.putAll(secondary.merge(currentConfig));
+			if(currentConfig != null) {
+				config.putAll(secondary.merge(currentConfig));
+			} else {
+				config.putAll(secondary);
+			}
 		}
 		return config;
 	}


### PR DESCRIPTION
My mergeConfig kept complaining about a null currentConfig.  Not sure if currentConfig is ever supposed to be null, but it's happening to me.  Using this allowed it to carry on.  This was with a new grails 2.3.4 app, springsecuritycore plugin and Facebook and openId plugins.
