### PR TITLE
support spring security oauth 2 default ScopeVoter prefix

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
+++ b/src/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
@@ -173,7 +173,7 @@ class ReflectionUtils {
 
 		for (String token : tokens) {
 			ConfigAttribute config = new SecurityConfig(token)
-			boolean supports = !expressions || token.startsWith('RUN_AS') || supports(config, roleVoter) || supports(config, authenticatedVoter)
+			boolean supports = !expressions || token.startsWith('RUN_AS') || token.startsWith('SCOPE') || supports(config, roleVoter) || supports(config, authenticatedVoter)
 			if (supports) {
 				configAttributes << config
 			}


### PR DESCRIPTION
Create SecurityConfig instead of WebExpressionConfigAttribute when the token is starting with 'SCOPE'. If not, the plugin will create a WebExpressionConfigAttribute when I have @Secured(['SCOPE_READ']). When calling WebExpressionConfigAttribute.getAttribute(), it always return null and the ScopeVoter is not able to execute the logic in the if block (https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/vote/ScopeVoter.java#L138)

https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/vote/ScopeVoter.java#L100
