### PR TITLE
Swapping out calls to ApplicationHolder for 2.4 compatibility

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.0.4
+app.grails.version=2.2.4

--- a/test/unit/grails/plugin/springsecurity/SpringSecurityUtilsTests.groovy
+++ b/test/unit/grails/plugin/springsecurity/SpringSecurityUtilsTests.groovy
@@ -200,14 +200,14 @@ class SpringSecurityUtilsTests extends GroovyTestCase {
 		assertTrue SpringSecurityUtils.ifAllGranted('ROLE_1,ROLE_2,ROLE_3')
 		assertTrue SpringSecurityUtils.ifAllGranted('ROLE_3')
 		assertFalse SpringSecurityUtils.ifAllGranted('ROLE_4')
-		
+
 		assertTrue SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_1')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_2')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_1'), new SimpleGrantedAuthority('ROLE_2')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_1'), new SimpleGrantedAuthority('ROLE_2'), new SimpleGrantedAuthority('ROLE_3')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_3')])
 		assertFalse SpringSecurityUtils.ifAllGranted([new SimpleGrantedAuthority('ROLE_4')])
-		
+
 		assertTrue SpringSecurityUtils.ifAllGranted([new GrantedAuthorityImpl('ROLE_1')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new GrantedAuthorityImpl('ROLE_2')])
 		assertTrue SpringSecurityUtils.ifAllGranted([new GrantedAuthorityImpl('ROLE_1'), new GrantedAuthorityImpl('ROLE_2')])
@@ -225,7 +225,7 @@ class SpringSecurityUtilsTests extends GroovyTestCase {
 		assertFalse SpringSecurityUtils.ifNotGranted('ROLE_1,ROLE_2')
 		assertFalse SpringSecurityUtils.ifNotGranted('ROLE_1,ROLE_2,ROLE_3')
 		assertTrue SpringSecurityUtils.ifNotGranted('ROLE_3')
-		
+
 		assertFalse SpringSecurityUtils.ifNotGranted([new SimpleGrantedAuthority('ROLE_1')])
 		assertFalse SpringSecurityUtils.ifNotGranted([new SimpleGrantedAuthority('ROLE_2')])
 		assertFalse SpringSecurityUtils.ifNotGranted([new SimpleGrantedAuthority('ROLE_1'), new SimpleGrantedAuthority('ROLE_2')])
@@ -319,7 +319,7 @@ class SpringSecurityUtilsTests extends GroovyTestCase {
 		def roleHierarchy = new RoleHierarchyImpl(hierarchy: hierarchy)
 		def ctx = [getBean: { String name -> roleHierarchy }] as ApplicationContext
 		def application = new FakeApplication(mainContext: ctx)
-		org.codehaus.groovy.grails.commons.ApplicationHolder.application = application
+		grails.util.Holders.grailsApplication = application
 		SpringSecurityUtils.application = application
 	}
 
@@ -332,8 +332,8 @@ class SpringSecurityUtilsTests extends GroovyTestCase {
 		super.tearDown()
 		SecurityTestUtils.logout()
 		SpringSecurityUtils.resetSecurityConfig()
-		org.codehaus.groovy.grails.commons.ApplicationHolder.application = null
-		org.codehaus.groovy.grails.commons.ConfigurationHolder.config = null
+		grails.util.Holders.grailsApplication = null
+		grails.util.Holders.config = null
 		SpringSecurityUtils.application = null
 		ReflectionUtils.application = null
 		SecurityRequestHolder.reset()


### PR DESCRIPTION
Replaced calls to ApplicationHolder in unit tests to grails.util.Holders also bumped version to 2.2.4. Could probably go higher on that. Currently Spring Security plugin (latest RC) does not function in grails 2.4.0.RC1 due to complaining about this ApplicationHolder.
