### PR TITLE
Support for adding logout handlers to existing list

### DIFF
--- a/SpringSecurityCoreGrailsPlugin.groovy
+++ b/SpringSecurityCoreGrailsPlugin.groovy
@@ -683,9 +683,12 @@ to default to 'Annotation'; setting value to 'Annotation'
 		ctx.authenticationManager.providers = createBeanList(providerNames, ctx)
 
 		// build handlers list here to give dependent plugins a chance to register some
+        def configuredLogoutHandlerNames = conf.logout.additionalHandlerNames
 		def logoutHandlerNames = conf.logout.handlerNames ?: SpringSecurityUtils.getLogoutHandlerNames()
 		ctx.logoutHandlers.clear()
 		ctx.logoutHandlers.addAll createBeanList(logoutHandlerNames, ctx)
+        // give users the option of not having to figure out all the other handlers in order to not overwrite them
+		ctx.logoutHandlers.addAll createBeanList(configuredLogoutHandlerNames, ctx)
 
 		// build after-invocation provider names here to give dependent plugins a chance to register some
 		def afterInvocationManagerProviderNames = conf.afterInvocationManagerProviderNames ?: SpringSecurityUtils.getAfterInvocationManagerProviderNames()

--- a/functional-test-app/grails-app/conf/BuildConfig.groovy
+++ b/functional-test-app/grails-app/conf/BuildConfig.groovy
@@ -67,7 +67,7 @@ mavenRepo 'http://repo.spring.io/milestone' // TODO remove
     plugins {
 		test ":geb:$gebVersion"
 
-		runtime ":spring-security-core:2.0-RC4"
+		runtime ":spring-security-core:2.0-SNAPSHOT"
 
         // plugins for the build system only
         build ":tomcat:7.0.54"

--- a/integration-test-app/grails-app/conf/BuildConfig.groovy
+++ b/integration-test-app/grails-app/conf/BuildConfig.groovy
@@ -55,7 +55,7 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        runtime ":spring-security-core:2.0-RC4"
+        runtime ":spring-security-core:2.0-SNAPSHOT"
 
         // plugins for the build system only
         build ":tomcat:7.0.54"

--- a/integration-test-app/grails-app/conf/Config.groovy
+++ b/integration-test-app/grails-app/conf/Config.groovy
@@ -162,6 +162,8 @@ grails {
             interceptUrlMap = [
                 '/testController/**':   ['roleInMap']
             ]
+
+            logout.additionalHandlerNames =[ 'screamingBratLogoutHandler']
 		}
 	}
 }

--- a/integration-test-app/grails-app/conf/spring/resources.groovy
+++ b/integration-test-app/grails-app/conf/spring/resources.groovy
@@ -1,3 +1,8 @@
+import com.test.ScreamingBratLogoutHandler
+
 // Place your Spring DSL code here
 beans = {
+
+    screamingBratLogoutHandler(ScreamingBratLogoutHandler)
+
 }

--- a/integration-test-app/src/java/com/test/ScreamingBratLogoutHandler.java
+++ b/integration-test-app/src/java/com/test/ScreamingBratLogoutHandler.java
@@ -1,0 +1,15 @@
+package com.test;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ScreamingBratLogoutHandler implements LogoutHandler {
+
+    @Override
+    public void logout(HttpServletRequest servletRequest, HttpServletResponse httpServletResponse, Authentication authentication) {
+    }
+
+}

--- a/integration-test-app/test/integration/grails/plugin/springsecurity/AdditionalLogoutFiltersConfiguredTests.groovy
+++ b/integration-test-app/test/integration/grails/plugin/springsecurity/AdditionalLogoutFiltersConfiguredTests.groovy
@@ -1,0 +1,49 @@
+/* Copyright 2006-2014 SpringSource.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package grails.plugin.springsecurity
+
+import com.test.ScreamingBratLogoutHandler
+import grails.plugin.springsecurity.web.authentication.logout.MutableLogoutFilter
+import grails.test.mixin.TestMixin
+import grails.test.mixin.integration.IntegrationTestMixin
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
+import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices
+
+import static org.junit.Assert.assertEquals
+
+/**
+ * @author <a href='mailto:george@georgemcintosh.com'>George McIntosh</a>
+ */
+@TestMixin(IntegrationTestMixin)
+class AdditionalLogoutFiltersConfiguredTests {
+
+    def grailsApplication
+
+    void testAllHandlersExist() {
+
+        def expected = [ScreamingBratLogoutHandler, SecurityContextLogoutHandler, TokenBasedRememberMeServices].sort()
+
+        def ctx = grailsApplication.mainContext
+        MutableLogoutFilter logoutFilter = ctx.logoutFilter
+        assertEquals 3, logoutFilter.handlers.size()
+
+        def handlerClasses = logoutFilter.handlers.collect { it.class }.sort()
+
+        assertEquals(expected, handlerClasses)
+
+    }
+
+
+}

--- a/src/docs/guide/logoutHandlers.gdoc
+++ b/src/docs/guide/logoutHandlers.gdoc
@@ -9,6 +9,13 @@ To customize this list, you define a @logout.handlerNames@ attribute with a list
 logout.handlerNames | \['rememberMeServices', 'securityContextLogoutHandler'\] | Logout handler bean names.
 {table}
 
+You can also add a handler to the existing list, which can be useful if you don't want to depend on the exact existing list in your config.
+
+{table}
+*Property* | *Default Value* | *Meaning*
+logout.additionalHandlerNames | \[\] | Additional logout handler bean names.
+{table}
+
 The beans must be declared either by the plugin or by you in @resources.groovy@ or @resources.xml@. For example, suppose you have a custom @MyLogoutHandler@ in @resources.groovy@:
 
 {code}


### PR DESCRIPTION
Rather than forcing users to re-configure *all* the logout handlers contributed by plugins etc, as well as their own, I added a way to simply configure *additional* handlers.

Also, I may be wrong, but shouldn't the integration and functional test apps run against the 2.0-SNAPSHOT of this plugin on master?