### PR TITLE
GPSPRINGSECURITYCORE-309 GormPersistentTokenRepository should use a transaction when retrieving persistent login

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/web/authentication/rememberme/GormPersistentTokenRepository.groovy
+++ b/src/groovy/grails/plugin/springsecurity/web/authentication/rememberme/GormPersistentTokenRepository.groovy
@@ -60,7 +60,10 @@ class GormPersistentTokenRepository implements PersistentTokenRepository, Grails
 		def persistentToken
 		def clazz = lookupDomainClass()
 		if (clazz) {
-			persistentToken = clazz.get(seriesId)
+			// join an existing transaction if one is active
+			clazz.withTransaction { status ->
+				persistentToken = clazz.get(seriesId)
+			}
 		}
 		if (!persistentToken) {
 			return null


### PR DESCRIPTION
See https://jira.grails.org/browse/GPSPRINGSECURITYCORE-309

After updating from Grails 2.3.11 to Grails 2.4.4 I was getting the following stacktrace relating to the persistent login lookup.

```
org.springframework.dao.DataAccessResourceFailureException: Could not obtain current Hibernate Session; nested exception is org.hibernate.HibernateException: No Session found for current thread
        at org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateTemplate.getSession(GrailsHibernateTemplate.java:210)
        at org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateTemplate.doExecute(GrailsHibernateTemplate.java:166)
        at org.codehaus.groovy.grails.orm.hibernate.GrailsHibernateTemplate.get(GrailsHibernateTemplate.java:239)
        at org.codehaus.groovy.grails.orm.hibernate.HibernateGormStaticApi.doGetInstance(HibernateGormStaticApi.groovy:129)
        at org.codehaus.groovy.grails.orm.hibernate.HibernateGormStaticApi.get(HibernateGormStaticApi.groovy:123)
        at net.bluetab.security.PersistentLogin.get(PersistentLogin.groovy)
        at net.bluetab.security.PersistentLogin$get.call(Unknown Source)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
        at grails.plugin.springsecurity.web.authentication.rememberme.GormPersistentTokenRepository.getTokenForSeries(GormPersistentTokenRepository.groovy:63)
        at org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices.processAutoLoginCookie(PersistentTokenBasedRememberMeServices.java:90)
        at org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices.autoLogin(AbstractRememberMeServices.java:115)
        at org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter.doFilter(RememberMeAuthenticationFilter.java:97)
        ...
```

This change should ensure there's a session present.