### PR TITLE
GPSPRINGSECURITYCORE-319 Change from net.sf.ehcache:ehcache-core to net....

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -40,7 +40,7 @@ grails.project.dependency.resolution = {
 			         'tomcat-servlet-api'
 		}
 
-		compile 'net.sf.ehcache:ehcache-core:2.6.9'
+		compile 'net.sf.ehcache:ehcache:2.9.0'
 	}
 
 	plugins {


### PR DESCRIPTION
...sf.ehcache:ehcache to align with dependency used by Grails 2.4.5 and newer