### PR TITLE
Test apps should use current version of plugin

### DIFF
--- a/functional-test-app/grails-app/conf/BuildConfig.groovy
+++ b/functional-test-app/grails-app/conf/BuildConfig.groovy
@@ -3,6 +3,8 @@ grails.project.work.dir = 'target'
 grails.project.target.level = 1.7
 grails.project.source.level = 1.7
 
+grails.plugin.location.'spring-security-core' = '..'
+
 grails.project.dependency.resolver = 'maven'
 grails.project.dependency.resolution = {
 	inherits 'global'
@@ -34,7 +36,6 @@ grails.project.dependency.resolution = {
 		build ':tomcat:7.0.54'
 
 		runtime ':hibernate:3.6.10.16'
-		runtime ':spring-security-core:2.0-SNAPSHOT'
 
 		test ":geb:$gebVersion"
 	}

--- a/functional-test-app/grails-app/conf/Config.groovy
+++ b/functional-test-app/grails-app/conf/Config.groovy
@@ -61,7 +61,7 @@ log4j = {
 }
 
 grails.plugin.springsecurity.authority.className = 'com.testapp.TestRole'
-grails.plugin.springsecurity.fii.rejectPublicInvocations = true
+grails.plugin.springsecurity.fii.rejectPublicInvocations = false
 grails.plugin.springsecurity.password.algorithm = 'SHA-256'
 grails.plugin.springsecurity.rejectIfNoRule = false
 grails.plugin.springsecurity.requestMap.className = 'com.testapp.TestRequestmap'

--- a/integration-test-app/grails-app/conf/BuildConfig.groovy
+++ b/integration-test-app/grails-app/conf/BuildConfig.groovy
@@ -3,6 +3,8 @@ grails.project.work.dir = 'target'
 grails.project.target.level = 1.7
 grails.project.source.level = 1.7
 
+grails.plugin.location.'spring-security-core' = '..'
+
 grails.project.dependency.resolver = 'maven'
 grails.project.dependency.resolution = {
 	inherits 'global'
@@ -23,7 +25,6 @@ grails.project.dependency.resolution = {
 	}
 
 	plugins {
-		runtime ':spring-security-core:2.0-SNAPSHOT'
 		runtime ':hibernate4:4.3.5.4'
 	}
 }


### PR DESCRIPTION
Also, `rejectPublicInvocations = true` was causing functional tests to fail