### PR TITLE
authAjax currently returns a status 200 with /authAjax using Grails 3

### DIFF
--- a/grails-app/controllers/grails/plugin/springsecurity/LoginController.groovy
+++ b/grails-app/controllers/grails/plugin/springsecurity/LoginController.groovy
@@ -63,7 +63,7 @@ class LoginController {
 	/** The redirect action for Ajax requests. */
 	def authAjax() {
 		response.setHeader 'Location', SpringSecurityUtils.securityConfig.auth.ajaxLoginFormUrl
-		response.sendError HttpServletResponse.SC_UNAUTHORIZED
+		render(status: HttpServletResponse.SC_UNAUTHORIZED, text: 'Unauthorized')
 	}
 
 	/** Show denied page. */


### PR DESCRIPTION
…This is a fix to make it compatible with Grails 3 and return the correct status code for UNAUTHORIZED.