### PR TITLE
Make overriding userDetailsService Spring Bean an easier task from within plugins

### DIFF
--- a/grails-app/conf/DefaultSecurityConfig.groovy
+++ b/grails-app/conf/DefaultSecurityConfig.groovy
@@ -70,6 +70,9 @@ security {
 
 	useExternalClasses = false
 
+	// Default UserDetailsService to use
+	userDetailsService = 'grails.plugin.springsecurity.userdetails.GormUserDetailsService'
+
 	// user and role class properties
 	userLookup {
 		userDomainClassName = null // must be set if using UserDetailsService

--- a/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
@@ -99,7 +99,6 @@ import grails.plugin.springsecurity.authentication.encoding.DigestAuthPasswordEn
 import grails.plugin.springsecurity.authentication.encoding.PBKDF2PasswordEncoder
 import grails.plugin.springsecurity.userdetails.DefaultPostAuthenticationChecks
 import grails.plugin.springsecurity.userdetails.DefaultPreAuthenticationChecks
-import grails.plugin.springsecurity.userdetails.GormUserDetailsService
 import grails.plugin.springsecurity.web.NullFilterChainValidator
 import grails.plugin.springsecurity.web.access.AjaxAwareAccessDeniedHandler
 import grails.plugin.springsecurity.web.access.DefaultThrowableAnalyzer
@@ -468,8 +467,8 @@ to default to 'Annotation'; setting value to 'Annotation'
 				}
 		}
 
-		/** userDetailsService */
-		userDetailsService(GormUserDetailsService) {
+		/** userDetailsService - loaded from DefaultSecurityConfig, can be overridden by application/plugin Config */
+		userDetailsService(this.class.classLoader.loadClass(SpringSecurityUtils.securityConfig.userDetailsService)) {
 			grailsApplication = grailsApplication
 		}
 


### PR DESCRIPTION
When I was developing a plugin to encapsulate the security logic of my application, I couldn't find a way to override the `userDetailsService` Spring Bean other way than adding some code to `resources.groovy`, which doesn't exists in a Grails plugin, only in Grails apps. It's not possible to override it in `doWithSpring` closure, so I needed to find a way to override it before the context was created. With this configuration, it was possible to override this bean in a cleaner way from within my plugin.