### PR TITLE
Added documentation about `RoleHierarchyEntry` updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 cobertura.ser
 kindlegen
 out
+atlassian-ide-plugin.xml

--- a/src/docs/hierarchicalRoles.adoc
+++ b/src/docs/hierarchicalRoles.adoc
@@ -111,3 +111,5 @@ if (!RoleHierarchyEntry.count()) {
    new RoleHierarchyEntry(entry: 'ROLE_FINANCE_ADMIN > ROLE_ADMIN').save()
 }
 ----
+
+Remember to update the `roleHierarchy` beans `hierarchy` definition by calling `SpringSecurityService#reloadDBRoleHierarchy`, or your model changes are not reflected in the running application.


### PR DESCRIPTION
A call to `grails.plugin.springsecurity.SpringSecurityService#reloadDBRoleHierarchy` is needed to use new/updated/deleted `RoleHierarchyEntity` instances.
