### PR TITLE
Support all link attributes for sec:access tag

### DIFF
--- a/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
@@ -14,6 +14,7 @@
  */
 package grails.plugin.springsecurity
 
+import grails.web.mapping.LinkGenerator
 import org.springframework.expression.EvaluationContext
 import org.springframework.expression.Expression
 import org.springframework.security.access.expression.ExpressionUtils
@@ -233,23 +234,14 @@ class SecurityTagLib {
 			return ExpressionUtils.evaluateAsBoolean(expression, ctx)
 		}
 
-		String url = attrs.remove('url')
-		if (!url) {
-			String controller = attrs.remove('controller')
-			String mapping = attrs.remove('mapping')
-			if (!controller && !mapping) {
-				throwTagError "Tag [$tagName] requires an expression, a URL, or controller/action/mapping attributes to create a URL"
-			}
-			if (mapping) {
-				url = g.createLink(mapping: mapping)
-			}
-			else {
-				String action = attrs.remove('action')
-				url = g.createLink(controller: controller, action: action, base: '/')
-			}
-		}
+		Map urlAttributes = attrs.subMap(LinkGenerator.LINK_ATTRIBUTES)
 
-		String method = attrs.remove('method') ?: 'GET'
+		if (!urlAttributes) {
+			throwTagError "Tag [$tagName] requires an expression, a URL, or controller/action/mapping attributes to create a URL"
+		}
+		String url = g.createLink(urlAttributes)
+
+		String method = urlAttributes.remove('method') ?: 'GET'
 
 		return webInvocationPrivilegeEvaluator.isAllowed(request.contextPath, url, method, auth)
 	}


### PR DESCRIPTION
This brings `<sec:access>` attribute parsing in-line with `<sec:link>` in that it passes all valid attributes to the `createLink` method.

Existing behaviors retained:
* unspecified method defaults to 'GET'
* if `url` is specified it is still processed, but the `DefaultLinkGenerator` prints it out unmodified (so section 6.1.11 Example 37 should still work)

This shouldn't break any existing apps that rely on any of the above behaviors.

Addresses https://github.com/grails-plugins/grails-spring-security-core/issues/486