### PR TITLE
bcrypt lower values for tests

### DIFF
--- a/grails-app/conf/DefaultSecurityConfig.groovy
+++ b/grails-app/conf/DefaultSecurityConfig.groovy
@@ -16,7 +16,7 @@ import grails.plugin.springsecurity.BeanTypeResolver
 import grails.plugin.springsecurity.SecurityConfigType
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.authentication.GrailsAnonymousAuthenticationToken
-
+import grails.util.Environment
 import org.springframework.security.authentication.RememberMeAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
@@ -186,11 +186,20 @@ security {
 	password {
 		algorithm = 'bcrypt'
 		encodeHashAsBase64 = false
-		bcrypt {
-			logrounds = 10
-		}
-		hash {
-			iterations = 10000
+		if (Environment.current == Environment.TEST) {
+			bcrypt {
+				logrounds = 4
+			}
+			hash {
+				iterations = 1
+			}
+		} else {
+			bcrypt {
+				logrounds = 10
+			}
+			hash {
+				iterations = 10000
+			}
 		}
 	}
 

--- a/src/docs/passwords/hashing.adoc
+++ b/src/docs/passwords/hashing.adoc
@@ -49,9 +49,5 @@ If you want to use a message digest hashing algorithm, see https://docs.oracle.c
 |the number of iterations which will be executed on the hashed password/salt when using a message digest algorithm
 |====================
 
-For performance reasons, the number of rounds and of hashing iterations are lowered to the minimum when running tests.
-`password.bcrypt.logrounds` is set to `4` and `password.hash.iterations` is set to `1` when
-`Environment.current == Environment.TEST`.
-
-If you override the bcrypt default values, do not forget to alo override the values for `TEST` if you want to retain
-this optimization.
+NOTE: The bcrypt `logrounds` and `iterations` are set to a lower number to improve speed while testing.
+If you rely on them to be higher, set them manually when testing.

--- a/src/docs/passwords/hashing.adoc
+++ b/src/docs/passwords/hashing.adoc
@@ -48,3 +48,10 @@ If you want to use a message digest hashing algorithm, see https://docs.oracle.c
 |`10000`
 |the number of iterations which will be executed on the hashed password/salt when using a message digest algorithm
 |====================
+
+For performance reasons, the number of rounds and of hashing iterations are lowered to the minimum when running tests.
+`password.bcrypt.logrounds` is set to `4` and `password.hash.iterations` is set to `1` when
+`Environment.current == Environment.TEST`.
+
+If you override the bcrypt default values, do not forget to alo override the values for `TEST` if you want to retain
+this optimization.


### PR DESCRIPTION
See #498

* Switch default `bcrypt` value based on `Environment.current`
* Updated doc