### PR TITLE
Issue #521: Informational messages are logged with level "WARN"

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
@@ -158,7 +158,7 @@ class SpringSecurityCoreGrailsPlugin extends Plugin {
 		if (!conf || !conf.active) {
 			if (printStatusMessages) {
 				String message = '\n\nSpring Security is disabled, not loading\n\n'
-				log.warn message
+				log.info message
 				println message
 			}
 			return
@@ -168,7 +168,7 @@ class SpringSecurityCoreGrailsPlugin extends Plugin {
 
 		if (printStatusMessages) {
 			String message = '\nConfiguring Spring Security Core ...'
-			log.warn message
+			log.info message
 			println message
 		}
 
@@ -632,7 +632,7 @@ to default to 'Annotation'; setting value to 'Annotation'
 
 		if (printStatusMessages) {
 			String message = '... finished configuring Spring Security Core\n'
-			log.warn message
+			log.info message
 			println message
 		}
 	}}


### PR DESCRIPTION
I left the `println`s in place because they are there so that developers may see the the current state of the `spring-security-core` plugin when the app starts, regardless of whether they've configured the correct log level.

I've modified all but one of the startup messages to utilize log level `info`.

This fixes issue #521 