### PR TITLE
Mitigate CVE-2018-1199

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply from: 'gradle/plugin.gradle'
 
 dependencies {
 	compile 'net.sf.ehcache:ehcache:2.9.0'
-	String springSecurityVersion = '4.1.0.RELEASE'
+	String springSecurityVersion = '4.1.5.RELEASE'
 	compile "org.springframework.security:spring-security-core:$springSecurityVersion", {
 		['spring-aop', 'spring-beans', 'spring-context', 'spring-core', 'spring-expression'].each { exclude module: it }
 	}


### PR DESCRIPTION
Upgrade to Spring Security 4.1.5.RELEASE.
See https://pivotal.io/security/cve-2018-1199.