### PR TITLE
Issue 546: Create an issue template similar to what is used in the grails-data-mapping plugin

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+Thanks for reporting an issue for grails-spring-security-core. Please review the task list below before submitting the 
+issue.
+
+
+> WARNING: Your issue report may be closed if the issue report is incomplete and does not include an example. Make sure the below tasks are completed!
+
+> NOTE: If you are unsure about something and the issue is more of a question, a better place to ask questions is on Stack Overflow (http://stackoverflow.com/tags/grails) or Slack (http://slack-signup.grails.org). DO NOT use the issue tracker to ask questions.
+
+### Task List
+
+- [ ] Steps to reproduce provided
+- [ ] Stacktrace (if present) provided
+- [ ] Example that reproduces the problem uploaded to Github
+- [ ] Full description of the issue provided (see below)
+
+### Steps to Reproduce
+
+1. TODO
+2. TODO
+3. TODO
+
+### Expected Behaviour
+
+Tell us what should happen
+
+### Actual Behaviour
+
+Tell us what happens instead
+
+### Environment Information
+
+- **Operating System**: TODO
+- **GORM Version:** TODO
+- **Grails Version (if using Grails):** TODO
+- **JDK Version:** TODO
+
+### Example Application
+
+- TODO: link to github repository with example that reproduces the issue


### PR DESCRIPTION
This will be great for prompting users to supply the information required to reproduce and fix the issue.

Example issue template: https://github.com/grails/grails-data-mapping/blob/master/ISSUE_TEMPLATE.md