### PR TITLE
Issue 548: modify documentation to clarify which filter chain is being modified

### DIFF
--- a/plugin/src/docs/filters.adoc
+++ b/plugin/src/docs/filters.adoc
@@ -7,7 +7,7 @@ There are a few different approaches to configuring filter chains.
 The default is to use configuration attributes to determine which extra filters to use (for example, Basic Auth, Switch User, etc.) and add these to the "`core`" filters. For example, setting `grails.plugin.springsecurity.useSwitchUserFilter = true` adds `switchUserProcessingFilter` to the filter chain (and in the correct order). The filter chain built here is applied to all URLs. If you need more flexibility, you can use `filterChain.chainMap` as discussed in *chainMap* below.
 
 === filterNames
-To define custom filters, to remove a core filter from the chain (not recommended), or to otherwise have control over the filter chain, you can specify the `filterNames` property as a list of strings. As with the default approach, the filter chain built here is applied to all URLs.
+To define custom filters, to remove a core filter from the Spring Security filter chain (not recommended), or to otherwise have control over the Spring Security filter chain, you can specify the `filterNames` property as a list of strings. As with the default approach, the Spring Security filter chain built here is applied to all URLs.
 
 For example:
 
@@ -22,7 +22,7 @@ grails.plugin.springsecurity.filterChain.filterNames = [
 ]
 ----
 
-This example creates a filter chain corresponding to the Spring beans with the specified names.
+This example creates a Spring Security filter chain corresponding to the Spring beans with the specified names.
 
 === chainMap
 Use the `filterChain.chainMap` attribute to define which filters are applied to different URL patterns. You define a Map that specifies one or more lists of filter bean names, each with a corresponding URL pattern.


### PR DESCRIPTION
Modified the documentation to clarify which filter chain is being modified as recommended in the following comment from Issue #548 :

>I think an additional note/comment in the documentation would be great, that the term filter chain in this context refers to the spring security filter chain. Usually when I hear the term I instinctively think of the application servers filter chain first.