### PR TITLE
Issue #552: Fix broken integration tests #552

### DIFF
--- a/functional-test-app/build.gradle
+++ b/functional-test-app/build.gradle
@@ -69,8 +69,8 @@ dependencies {
 }
 
 webdriverBinaries {
-    chromedriver '2.34'
-    geckodriver '0.18.0'
+    chromedriver '2.38'
+    geckodriver '0.20.0'
 }
 
 apply from: "${rootProject.projectDir}/gradle/integrationTest.gradle"
@@ -84,3 +84,16 @@ assets {
     minifyJs = true
     minifyCss = true
 }
+
+// Uncomment the following to cause Gradle to output more information to stdout for test failures.
+// This may be useful when debugging test failures on Travis
+//tasks.withType(Test) {
+//    systemProperty "geb.env", System.getProperty('geb.env')
+//    systemProperty "geb.build.reportsDir", reporting.file("reportes")
+//
+//    beforeTest { descriptor -> logger.quiet " -- $descriptor" }
+//    testLogging {
+//        events "passed", "skipped", "failed"
+//        exceptionFormat 'full'
+//    }
+//}


### PR DESCRIPTION
Integration tests failed if run in a `chromeHeadless` environment.

Upgrading the `chromedriver` and `geckodriver` to more recent versions resolved the issue.

I also added some additional code to `build.gradle` that users may comment out if they wish to see more test failure details in Travis.  It helps with troubleshooting.

This PR is for issue #552 