### PR TITLE
Issue #554: Grails params missing values with PUT and PATCH after add spring security core

### DIFF
--- a/functional-test-app/build.gradle
+++ b/functional-test-app/build.gradle
@@ -60,6 +60,7 @@ dependencies {
         exclude group: 'org.gebish', module: 'geb-core'
     }
     testCompile "org.gebish:geb-core:$gebVersion"
+    testCompile "org.grails:grails-datastore-rest-client:5.0.0.RC2"
     testRuntime "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion"
     testRuntime "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
     testCompile "org.seleniumhq.selenium:selenium-remote-driver:$seleniumVersion"

--- a/functional-test-app/grails-app/controllers/com/testapp/TestFormParamsController.groovy
+++ b/functional-test-app/grails-app/controllers/com/testapp/TestFormParamsController.groovy
@@ -1,0 +1,31 @@
+package com.testapp
+
+import grails.plugin.springsecurity.annotation.Secured
+import grails.validation.Validateable
+import org.springframework.web.bind.annotation.PutMapping
+
+/**
+ * This controller is used to verify that parameters on PUT and PATCH requests are available
+ */
+@Secured(['permitAll'])
+class TestFormParamsController {
+
+    static allowedMethods = [
+            index: ["PUT", "PATCH"]
+    ]
+
+    @PutMapping
+    def index(TestFormCommand cmd) {
+        render "username: ${cmd.username}, password: ${cmd.password}"
+    }
+}
+
+class TestFormCommand implements Validateable {
+    String username
+    String password
+
+    static constraints = {
+        username(nullable: true)
+        password(nullable: true)
+    }
+}

--- a/functional-test-app/src/integration-test/groovy/specs/TestFormParamsSpec.groovy
+++ b/functional-test-app/src/integration-test/groovy/specs/TestFormParamsSpec.groovy
@@ -1,0 +1,122 @@
+package specs
+
+import grails.plugins.rest.client.RestBuilder
+import grails.plugins.rest.client.RestResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.client.RestTemplate
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ System.getProperty('TESTCONFIG') == 'requestmap' })
+class TestFormParamsSpec extends AbstractSecuritySpec {
+    @Value('${local.server.port}')
+    Integer serverPort
+    private final String USERNAME = "Admin"
+    private final String PASSWORD = "myPassword"
+
+    void 'PUT request with no parameters'() {
+        given:
+        RestBuilder restBuilder = new RestBuilder()
+
+        when: "A PUT request with no parameters is made"
+        RestResponse response = restBuilder.put("http://localhost:${serverPort}/testFormParams") {
+            contentType("application/x-www-form-urlencoded")
+        }
+
+        then: "the controller responds with the correct status and parameters are null"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: null, password: null"
+    }
+
+    void 'PUT request with parameters in the URL'() {
+        given:
+        RestBuilder restBuilder = new RestBuilder()
+
+        when: "A PUT request with no parameters is made"
+        RestResponse response = restBuilder.put("http://localhost:${serverPort}/testFormParams?username=${USERNAME}&password=${PASSWORD}") {
+            contentType("application/x-www-form-urlencoded")
+        }
+
+        then: "the controller responds with the correct status and parameters are extracted"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: ${USERNAME}, password: ${PASSWORD}"
+    }
+
+    void 'PUT request with parameters as x-www-form-urlencoded'() {
+        given: "a RestBuilder"
+        RestBuilder restBuilder = new RestBuilder()
+
+        and: "a form with username and password params"
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>()
+        form.add("username", USERNAME)
+        form.add("password", PASSWORD)
+
+        when: "A PUT request with form params is made"
+        RestResponse response = restBuilder.put("http://localhost:${serverPort}/testFormParams") {
+            contentType("application/x-www-form-urlencoded")
+            body(form)
+        }
+
+        then: "the controller responds with the correct status and parameters are extracted"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: ${USERNAME}, password: ${PASSWORD}"
+    }
+
+    void 'PATCH request with no parameters'() {
+        given: "An HTTP client that supports PATCH requests"
+        RestTemplate restTemplate = new RestTemplate()
+        restTemplate.requestFactory = new HttpComponentsClientHttpRequestFactory()
+        RestBuilder restBuilder = new RestBuilder(restTemplate)
+
+        when: "A PATCH request with no parameters is made"
+        RestResponse response = restBuilder.patch("http://localhost:${serverPort}/testFormParams") {
+            contentType("application/x-www-form-urlencoded")
+        }
+
+        then: "the controller responds with the correct status and parameters are null"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: null, password: null"
+    }
+
+    void 'PATCH request with parameters in the URL'() {
+        given: "An HTTP client that supports PATCH requests"
+        RestTemplate restTemplate = new RestTemplate()
+        restTemplate.requestFactory = new HttpComponentsClientHttpRequestFactory()
+        RestBuilder restBuilder = new RestBuilder(restTemplate)
+
+        when: "A PATCH request with no parameters is made"
+        RestResponse response = restBuilder.patch("http://localhost:${serverPort}/testFormParams?username=${USERNAME}&password=${PASSWORD}") {
+            contentType("application/x-www-form-urlencoded")
+        }
+
+        then: "the controller responds with the correct status and parameters are extracted"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: ${USERNAME}, password: ${PASSWORD}"
+    }
+
+    void 'PATCH request with parameters as x-www-form-urlencoded'() {
+        given: "An HTTP client that supports PATCH requests"
+        RestTemplate restTemplate = new RestTemplate()
+        restTemplate.requestFactory = new HttpComponentsClientHttpRequestFactory()
+        RestBuilder restBuilder = new RestBuilder(restTemplate)
+
+        and: "a form with username and password params"
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>()
+        form.add("username", USERNAME)
+        form.add("password", PASSWORD)
+
+        when: "A PATCH request with form params is made"
+        RestResponse response = restBuilder.patch("http://localhost:${serverPort}/testFormParams") {
+            contentType("application/x-www-form-urlencoded")
+            body(form)
+        }
+
+        then: "the controller responds with the correct status and parameters are extracted"
+        response.status == HttpStatus.OK.value()
+        response.text == "username: ${USERNAME}, password: ${PASSWORD}"
+    }
+
+}

--- a/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SpringSecurityUtilsIntegrationSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SpringSecurityUtilsIntegrationSpec.groovy
@@ -28,6 +28,7 @@ import org.springframework.security.web.access.intercept.FilterSecurityIntercept
 import org.springframework.security.web.context.SecurityContextPersistenceFilter
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter
 import org.springframework.web.filter.GenericFilterBean
+import org.springframework.web.filter.HttpPutFormContentFilter
 import test.TestRole
 import test.TestUser
 import test.TestUserRole
@@ -82,7 +83,7 @@ class SpringSecurityUtilsIntegrationSpec extends AbstractIntegrationSpec {
 		def map = SpringSecurityUtils.configuredOrderedFilters
 
 		expect:
-		9 == map.size()
+		10 == map.size()
 		map[Integer.MIN_VALUE + 10] instanceof SecurityRequestHolderFilter
 		map[300] instanceof SecurityContextPersistenceFilter
 		map[400] instanceof MutableLogoutFilter
@@ -90,8 +91,9 @@ class SpringSecurityUtilsIntegrationSpec extends AbstractIntegrationSpec {
 		map[1400] instanceof SecurityContextHolderAwareRequestFilter
 		map[1500] instanceof GrailsRememberMeAuthenticationFilter
 		map[1600] instanceof GrailsAnonymousAuthenticationFilter
-		map[1800] instanceof ExceptionTranslationFilter
-		map[1900] instanceof FilterSecurityInterceptor
+		map[1800] instanceof HttpPutFormContentFilter
+		map[1900] instanceof ExceptionTranslationFilter
+		map[2000] instanceof FilterSecurityInterceptor
 
 		when:
 		SpringSecurityUtils.clientRegisterFilter 'foo', SecurityFilterPosition.LOGOUT_FILTER
@@ -118,7 +120,7 @@ class SpringSecurityUtilsIntegrationSpec extends AbstractIntegrationSpec {
 		SpringSecurityUtils.clientRegisterFilter 'dummyFilter', SecurityFilterPosition.LOGOUT_FILTER.order + 10
 
 		then:
-		10 == map.size()
+		11 == map.size()
 		map[410] instanceof DummyFilter
 
 		when:
@@ -133,8 +135,9 @@ class SpringSecurityUtilsIntegrationSpec extends AbstractIntegrationSpec {
 		filters[5] instanceof SecurityContextHolderAwareRequestFilter
 		filters[6] instanceof GrailsRememberMeAuthenticationFilter
 		filters[7] instanceof GrailsAnonymousAuthenticationFilter
-		filters[8] instanceof ExceptionTranslationFilter
-		filters[9] instanceof FilterSecurityInterceptor
+		filters[8] instanceof HttpPutFormContentFilter
+		filters[9] instanceof ExceptionTranslationFilter
+		filters[10] instanceof FilterSecurityInterceptor
 	}
 
 	void 'reauthenticate'() {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.groovy
@@ -59,6 +59,8 @@ enum SecurityFilterPosition {
 	ANONYMOUS_FILTER,
 	/** SessionManagementFilter */
 	SESSION_MANAGEMENT_FILTER,
+	/** Spring HttpPutFormContentFilter allows www-url-form-encoded content-types to provide params in PUT requests */
+	HTTP_PUT_FORM_CONTENT_FILTER,
 	/** ExceptionTranslationFilter */
 	EXCEPTION_TRANSLATION_FILTER,
 	/** FilterSecurityInterceptor */

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
@@ -124,6 +124,7 @@ import org.springframework.security.web.savedrequest.NullRequestCache
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter
 import org.springframework.security.web.session.HttpSessionEventPublisher
 import org.springframework.security.web.util.matcher.AnyRequestMatcher
+import org.springframework.web.filter.HttpPutFormContentFilter
 
 import javax.servlet.DispatcherType
 
@@ -635,6 +636,8 @@ to default to 'Annotation'; setting value to 'Annotation'
 			log.info message
 			println message
 		}
+
+		httpPutFormContentFilter(classFor('httpPutFormContentFilter', HttpPutFormContentFilter))
 	}}
 
 	void doWithApplicationContext() {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
@@ -745,6 +745,8 @@ final class SpringSecurityUtils {
 				orderedNames[SecurityFilterPosition.SWITCH_USER_FILTER.order] = 'switchUserProcessingFilter'
 			}
 
+			orderedNames[SecurityFilterPosition.HTTP_PUT_FORM_CONTENT_FILTER.order] = 'httpPutFormContentFilter'
+
 			// add in filters contributed by secondary plugins
 			orderedNames << SpringSecurityUtils.orderedFilters
 		}


### PR DESCRIPTION
Issue #554: Grails params missing values with PUT and PATCH after add spring security core

PUT requests with content-type `application/x-www-form-urlencoded` were not returning parameters when grails-spring-security-core was enabled.

The reason is that the `HttpPutFormContentFilter` was not registered.  Registering it allows for PUT requests to work as expected.

This commit registers the filter and updates existing tests that the change broke.

Summary:

- added `testCompile "org.grails:grails-datastore-rest-client:5.0.0.RC2"`to `build.gradle` so that I may have access to `RestBuilder` from within functional tests
- added tests for `PUT` and `PATCH` requests that verify parameters are available for content-types of "application/x-www-form-urlencoded"
- added a test controller for use during functional tests
- fixed broken Travis CI build