### PR TITLE
Issue #503: Registering filter breaks the chain map

### DIFF
--- a/functional-test-app/build.gradle
+++ b/functional-test-app/build.gradle
@@ -60,6 +60,7 @@ dependencies {
         exclude group: 'org.gebish', module: 'geb-core'
     }
     testCompile "org.gebish:geb-core:$gebVersion"
+    testCompile "org.grails:grails-datastore-rest-client:5.0.0.RC2"
     testRuntime "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion"
     testRuntime "org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion"
     testCompile "org.seleniumhq.selenium:selenium-remote-driver:$seleniumVersion"

--- a/functional-test-app/grails-app/conf/spring/resources.groovy
+++ b/functional-test-app/grails-app/conf/spring/resources.groovy
@@ -1,5 +1,7 @@
+import com.testapp.MaintenanceModeFilter
 import com.testapp.TestUserPasswordEncoderListener
 import grails.plugin.springsecurity.SpringSecurityUtils
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import test.TestRequestmapFilterInvocationDefinition
 
 beans = {
@@ -10,6 +12,15 @@ beans = {
 			if (reject instanceof Boolean) {
 				rejectIfNoRule = reject
 			}
+		}
+	}
+
+	String testconfig = System.getProperty('TESTCONFIG')
+	if (testconfig == 'issue503') {
+		maintenanceModeFilter(MaintenanceModeFilter)
+		maintenanceModeFilterDeregistrationBean(FilterRegistrationBean) {
+			filter = ref("maintenanceModeFilter")
+			enabled = false
 		}
 	}
 }

--- a/functional-test-app/grails-app/init/functional/test/app/BootStrap.groovy
+++ b/functional-test-app/grails-app/init/functional/test/app/BootStrap.groovy
@@ -1,5 +1,15 @@
 package functional.test.app
 
+import grails.plugin.springsecurity.SecurityFilterPosition
+import grails.plugin.springsecurity.SpringSecurityUtils
+
 class BootStrap {
-	def init = {}
+    def init = { servletContext ->
+        String testconfig = System.getProperty('TESTCONFIG')
+        switch (testconfig) {
+            case 'issue503':
+                SpringSecurityUtils.clientRegisterFilter 'maintenanceModeFilter', SecurityFilterPosition.FILTER_SECURITY_INTERCEPTOR.order + 10
+                break
+        }
+    }
 }

--- a/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
+++ b/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
@@ -1,0 +1,27 @@
+package specs
+
+import grails.plugins.rest.client.RestBuilder
+import grails.plugins.rest.client.RestResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+
+@IgnoreIf({ System.getProperty('TESTCONFIG') != 'issue503' })
+@Issue('https://github.com/grails-plugins/grails-spring-security-core/issues/503')
+class CustomFilterRegistrationSpec extends AbstractSecuritySpec {
+
+    @Value('${local.server.port}')
+    Integer serverPort
+
+    void 'GET request to /assets/spinner.gif should not throw error because custom filter is excluded'() {
+        given: "MaintenanceModeFilter is registered in BootStrap and we have a restBuilder"
+        RestBuilder restBuilder = new RestBuilder()
+
+        when: "A GET request to the assets directory is made"
+        RestResponse response = restBuilder.get("http://localhost:${serverPort}/assets/spinner.gif")
+
+        then: "the filter is not invoked because of the chainMap defition of filters: 'none' in application.groovy"
+        response.status == HttpStatus.OK.value()
+    }
+}

--- a/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
+++ b/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
@@ -2,7 +2,6 @@ package specs
 
 import grails.plugins.rest.client.RestBuilder
 import grails.plugins.rest.client.RestResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -10,9 +9,6 @@ import spock.lang.Issue
 @IgnoreIf({ System.getProperty('TESTCONFIG') != 'issue503' })
 @Issue('https://github.com/grails-plugins/grails-spring-security-core/issues/503')
 class CustomFilterRegistrationSpec extends AbstractSecuritySpec {
-
-    @Value('${local.server.port}')
-    Integer serverPort
 
     void 'GET request to /assets/spinner.gif should not throw error because custom filter is excluded'() {
         given: "MaintenanceModeFilter is registered in BootStrap and we have a restBuilder"

--- a/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
+++ b/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
@@ -1,0 +1,20 @@
+package com.testapp
+
+import groovy.util.logging.Slf4j
+import org.springframework.web.filter.GenericFilterBean
+
+import javax.servlet.FilterChain
+import javax.servlet.ServletException
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+
+/**
+ * If registered, this filter results in an HttpStatus of 500 being returned to the client
+ */
+@Slf4j
+class MaintenanceModeFilter extends GenericFilterBean {
+
+    void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        throw NullPointerException()
+    }
+}

--- a/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
+++ b/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
@@ -15,6 +15,6 @@ import javax.servlet.ServletResponse
 class MaintenanceModeFilter extends GenericFilterBean {
 
     void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
-        throw NullPointerException()
+        throw new NullPointerException()
     }
 }

--- a/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
+++ b/functional-test-app/src/main/groovy/com/testapp/MaintenanceModeFilter.groovy
@@ -7,6 +7,8 @@ import javax.servlet.FilterChain
 import javax.servlet.ServletException
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 
 /**
  * If registered, this filter results in an HttpStatus of 500 being returned to the client
@@ -15,6 +17,14 @@ import javax.servlet.ServletResponse
 class MaintenanceModeFilter extends GenericFilterBean {
 
     void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
-        throw new NullPointerException()
+        HttpServletRequest request = (HttpServletRequest)req
+        HttpServletResponse response = (HttpServletResponse)res
+
+        if(request.requestURI in ['/hack/blankPage', '/error']) {
+            chain.doFilter request, response
+        } else {
+            throw new NullPointerException()
+        }
+
     }
 }

--- a/gradle/testVerbose.gradle
+++ b/gradle/testVerbose.gradle
@@ -1,8 +1,11 @@
-test {
+tasks.withType(Test) {
     testLogging {
         exceptionFormat = 'full'
-        events 'failed', 'standardOut', 'standardError'
+        events 'passed', 'failed', 'standardOut', 'standardError'
     }
+
+    reports.html.enabled = !System.getenv("TRAVIS")
+    reports.junitXml.enabled = !System.getenv("TRAVIS")
 
     beforeTest { descriptor -> logger.quiet " -- $descriptor" }
 }

--- a/integration-test-app/build.gradle
+++ b/integration-test-app/build.gradle
@@ -70,10 +70,4 @@ assets {
     minifyCss = true
 }
 
-integrationTest {
-    testLogging {
-        exceptionFormat = 'full'
-        events 'failed', 'standardOut', 'standardError'
-    }
-    beforeTest { descriptor -> logger.quiet " -- $descriptor" }
-}
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"

--- a/misc-functional-test-app/grails-spring-security-group/build.gradle
+++ b/misc-functional-test-app/grails-spring-security-group/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 }
 
 apply from: "${rootProject.projectDir}/gradle/ssc.gradle"
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"
 
 bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')

--- a/misc-functional-test-app/grails-spring-security-hierarchical-roles/build.gradle
+++ b/misc-functional-test-app/grails-spring-security-hierarchical-roles/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     compile project(':spring-security-core')
 }
 
+apply from: "${rootProject.projectDir}/gradle/testVerbose.gradle"
+
 bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')
     addResources = true

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
@@ -97,6 +97,7 @@ final class SpringSecurityUtils {
 	public static final String NO_ROLE = 'ROLE_NO_ROLES'
 
 	public static final String XML_HTTP_REQUEST = 'XMLHttpRequest'
+	public static final String FILTERS_NONE = 'none'
 
 	private SpringSecurityUtils() {
 		// static only
@@ -461,7 +462,7 @@ final class SpringSecurityUtils {
 			String filters = entry.filters ?: ''
 			String[] filtersArray = filters.split(',')
 
-			if (filtersArray.size() == 1 && filtersArray[0] == 'none') {
+			if (filtersArray.size() == 1 && filtersArray[0] == FILTERS_NONE) {
 				return true
 			}
 
@@ -788,7 +789,7 @@ final class SpringSecurityUtils {
 			for (Map<String, ?> entry in chainMap) {
 				String value = (entry.filters ?: '').toString().trim()
 				List<Filter> filters
-				if (value.toLowerCase() == 'none') {
+				if (value.toLowerCase() == FILTERS_NONE) {
 					filters = Collections.emptyList()
 				}
 				else if (value.contains('JOINED_FILTERS')) {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
@@ -145,7 +145,7 @@ final class SpringSecurityUtils {
 		}
 
 		// remove the fake role if it's there
-		Collection<GrantedAuthority> copy = ([] + authorities) as Collection
+		Collection<GrantedAuthority> copy = ([] + authorities) as Collection<GrantedAuthority>
 		for (Iterator<GrantedAuthority> iter = copy.iterator(); iter.hasNext();) {
 			if (NO_ROLE == iter.next().authority) {
 				iter.remove()
@@ -798,7 +798,7 @@ final class SpringSecurityUtils {
 							throw new IllegalArgumentException("Cannot add a filter to JOINED_FILTERS, can only remove: $item")
 						}
 					}
-					filters = copy.values() as List
+					filters = copy.values() as List<Filter>
 				}
 				else {
 					// explicit filter names

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
@@ -437,7 +437,7 @@ final class SpringSecurityUtils {
 		List<Map<String, ?>> chainMap = (List)(ReflectionUtils.getConfigProperty('filterChain.chainMap') ?: [])
 		for (GrailsSecurityFilterChain filterChain in filterChains) {
 
-			if (noFilterIsApplied(chainMap, filterChain.matcherPattern, beanName) || filterIsExcluded(chainMap, filterChain.matcherPattern, beanName)) {
+			if (noFilterIsApplied(chainMap, filterChain.matcherPattern) || filterIsExcluded(chainMap, filterChain.matcherPattern, beanName)) {
 				continue
 			}
 
@@ -453,23 +453,14 @@ final class SpringSecurityUtils {
 		}
 	}
 
-	private static boolean noFilterIsApplied(List<Map<String, ?>> chainMap, String pattern, String filterName) {
-		for (Map<String, ?> entry in chainMap) {
-			if (entry.pattern != pattern) {
-				continue
-			}
-
-			String filters = entry.filters ?: ''
-			String[] filtersArray = filters.split(',')
-
-			if (filtersArray.size() == 1 && filtersArray[0] == FILTERS_NONE) {
-				return true
-			}
-
+	public static boolean noFilterIsApplied(List<Map<String, ?>> chainMap, String pattern) {
+		Map<String, ?> entry = chainMap.find { Map<String, ?> entry -> entry.pattern == pattern }
+		if (!entry) {
 			return false
 		}
-
-		return false
+		String filters = entry.filters ?: ''
+		String[] filtersArray = filters.split(',')
+		(filtersArray.size() == 1 && filtersArray[0] == FILTERS_NONE)
 	}
 
 	private static boolean filterIsExcluded(List<Map<String, ?>> chainMap, String pattern, String filterName) {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityUtils.groovy
@@ -436,7 +436,7 @@ final class SpringSecurityUtils {
 		List<Map<String, ?>> chainMap = (List)(ReflectionUtils.getConfigProperty('filterChain.chainMap') ?: [])
 		for (GrailsSecurityFilterChain filterChain in filterChains) {
 
-			if (filterIsExcluded(chainMap, filterChain.matcherPattern, beanName)) {
+			if (noFilterIsApplied(chainMap, filterChain.matcherPattern, beanName) || filterIsExcluded(chainMap, filterChain.matcherPattern, beanName)) {
 				continue
 			}
 
@@ -450,6 +450,25 @@ final class SpringSecurityUtils {
 			filterChain.filters.clear()
 			filterChain.filters.addAll filters
 		}
+	}
+
+	private static boolean noFilterIsApplied(List<Map<String, ?>> chainMap, String pattern, String filterName) {
+		for (Map<String, ?> entry in chainMap) {
+			if (entry.pattern != pattern) {
+				continue
+			}
+
+			String filters = entry.filters ?: ''
+			String[] filtersArray = filters.split(',')
+
+			if (filtersArray.size() == 1 && filtersArray[0] == 'none') {
+				return true
+			}
+
+			return false
+		}
+
+		return false
 	}
 
 	private static boolean filterIsExcluded(List<Map<String, ?>> chainMap, String pattern, String filterName) {

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/SpringSecurityUtilsSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/SpringSecurityUtilsSpec.groovy
@@ -23,6 +23,7 @@ import org.springframework.security.web.FilterChainProxy
 import org.springframework.security.web.PortResolverImpl
 import org.springframework.security.web.savedrequest.DefaultSavedRequest
 import org.springframework.web.filter.GenericFilterBean
+import spock.lang.Unroll
 
 import javax.servlet.FilterChain
 import javax.servlet.ServletRequest
@@ -55,6 +56,18 @@ class SpringSecurityUtilsSpec extends AbstractUnitSpec {
 
 		applicationContext.securityFilterChains[0].filters.clear()
 		applicationContext.securityFilterChains[0].filters << applicationContext.firstDummy << applicationContext.secondDummy
+	}
+
+	@Unroll("noFiltersIsApplied returns #expected for pattern #pattern, chainMap => [pattern: #chainMapPattern, filters: #chainMapFilters]")
+	void "verifies noFiltersIsApplied "(String chainMapPattern, String chainMapFilters, String pattern, boolean expected) {
+		expect:
+		SpringSecurityUtils.noFilterIsApplied([[pattern: chainMapPattern, filters: chainMapFilters]], pattern) == expected
+
+		where:
+		chainMapPattern | chainMapFilters 	| pattern		| expected
+		'/assets/**'    | 'JOINED_FILTERS'  | '/assets/**'	| false
+		'/assets/**'    | 'none'            | '/assets/**'  | true
+		'/foo'          | 'none'            | '/assets/**'  | false
 	}
 
 	void 'should retain existing chainmap'() {

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -90,6 +90,12 @@ if [[ $EXIT_STATUS -ne 0 ]]; then
     exit $EXIT_STATUS
 fi
 
+./gradlew -DTESTCONFIG=issue503 -Dgeb.env=chromeHeadless functional-test-app:check || EXIT_STATUS=$?
+if [[ $EXIT_STATUS -ne 0 ]]; then
+    echo "Functional tests for Spring Security - TESTCONFIG:issue503 - check failed "
+    exit $EXIT_STATUS
+fi
+
 
 # Only publish if the branch is on master, and it is not a PR
 if [[ -n $TRAVIS_TAG ]] || [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then


### PR DESCRIPTION
This bug occurs when a custom filter is added by calling `SpringSecurityUtils.clientRegisterFilter` in `BootStrap.groovy`.

The `clientRegisterFilter` method calls `mergeFilterChains` which properly handles excluded filters, but does not address the situation where a chainMap pattern is associated with no filters, i.e.:

```
grails.plugin.springsecurity.filterChain.chainMap = [
				[pattern: '/assets/**',      filters: 'none']
]
```

Everything works as expected for non-custom loaded filters because `buildFilterChains` is called for all default chains and properly handles chain maps with `filters: 'none'`.

This fix modifies `clientRegisterFilter` to take `filters: 'none''` into account.

---

This PR is for Issue #503 