### PR TITLE
Add fallback attribute to link tag

### DIFF
--- a/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityTagLibSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityTagLibSpec.groovy
@@ -300,7 +300,6 @@ class SecurityTagLibSpec extends AbstractIntegrationSpec {
 		assertOutputEquals body, """<sec:link controller="testController" action="testAction" fallback="true">$body</sec:link>"""
 
 		when:
-		// role 'roleInMap' mapped to controller via interceptUrlMap in Config.groovy
 		authenticate 'roleInMap'
 
 		then:

--- a/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityTagLibSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityTagLibSpec.groovy
@@ -269,6 +269,45 @@ class SecurityTagLibSpec extends AbstractIntegrationSpec {
 		                   """<sec:link controller="testController" action="testAction" expression="hasRole('role1')">$body</sec:link>"""
 	}
 
+	void '<sec:link fallback="true"> via expression'() {
+		when:
+		String body = 'Test link'
+
+		then:
+		assertOutputEquals "", """<sec:link controller="testController" action="testAction" expression="hasRole('role1')" fallback="false">$body</sec:link>"""
+
+		then:
+		assertOutputEquals body, """<sec:link controller="testController" action="testAction" expression="hasRole('role1')" fallback="true">$body</sec:link>"""
+
+		when:
+		authenticate 'role1'
+
+		then:
+		assertOutputEquals 'test', """<sec:access expression="hasRole('role1')">test</sec:access>"""
+		assertOutputEquals """<a href="/testController/testAction">$body</a>""",
+				"""<sec:link controller="testController" action="testAction" expression="hasRole('role1')" fallback="true">$body</sec:link>"""
+	}
+
+	@Ignore
+	void '<sec:link fallback="true"> via url'() {
+		when:
+		String body = 'Test link'
+
+		then:
+		assertOutputEquals '', """<sec:link controller="testController" action="testAction" fallback="false">$body</sec:link>"""
+
+		then:
+		assertOutputEquals body, """<sec:link controller="testController" action="testAction" fallback="true">$body</sec:link>"""
+
+		when:
+		// role 'roleInMap' mapped to controller via interceptUrlMap in Config.groovy
+		authenticate 'roleInMap'
+
+		then:
+		assertOutputEquals """<a href="/testController/testAction">$body</a>""",
+				"""<sec:link controller="testController" action="testAction" fallback="true">$body</sec:link>"""
+	}
+
 	@Ignore
 	void '<sec:link> via url'() {
 		when:

--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
@@ -263,13 +263,9 @@ class SecurityTagLib implements GrailsConfigurationAware {
 			fallback = o
 		} else {
 			if (o != null) {
-				try {
-					def str = o.toString()
-					if (str) {
-						fallback = Boolean.parseBoolean(str)
-					}
-				} catch(e) {
-					log.error 'Failed to parse attribute [fallback] for tag [link], defaulting to false', e
+				def str = o.toString()
+				if (str) {
+					fallback = Boolean.parseBoolean(str)
 				}
 			}
 		}

--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
@@ -205,8 +205,7 @@ class SecurityTagLib implements GrailsConfigurationAware {
 		// retain original attributes for later, since hasAccess() removes ones necessary to create a link
 		def origAttrsMinusExpression = [:] + attrs
 		origAttrsMinusExpression.remove 'expression'
-		boolean hasAccess = hasAccess(attrs, 'link')
-		if (hasAccess) {
+		if (hasAccess(attrs, 'link')) {
 			out << g.link(origAttrsMinusExpression, body)
 			return
 		}
@@ -269,7 +268,9 @@ class SecurityTagLib implements GrailsConfigurationAware {
 					if (str) {
 						fallback = Boolean.parseBoolean(str)
 					}
-				} catch(e){}
+				} catch(e) {
+					log.error 'Failed to parse attribute [fallback] for tag [link], defaulting to false', e
+				}
 			}
 		}
 		return fallback

--- a/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
+++ b/plugin/grails-app/taglib/grails/plugin/springsecurity/SecurityTagLib.groovy
@@ -201,11 +201,18 @@ class SecurityTagLib implements GrailsConfigurationAware {
 	 * Renders the link if the user has access to the specified URL.
 	 */
 	def link = { attrs, body ->
+		boolean isFallback = isFallback(attrs)
 		// retain original attributes for later, since hasAccess() removes ones necessary to create a link
 		def origAttrsMinusExpression = [:] + attrs
 		origAttrsMinusExpression.remove 'expression'
-		if (hasAccess(attrs, 'link')) {
+		boolean hasAccess = hasAccess(attrs, 'link')
+		if (hasAccess) {
 			out << g.link(origAttrsMinusExpression, body)
+			return
+		}
+
+		if (isFallback) {
+			out << body()
 		}
 	}
 
@@ -248,6 +255,24 @@ class SecurityTagLib implements GrailsConfigurationAware {
 		String method = urlAttributes.remove('method') ?: 'GET'
 
 		return webInvocationPrivilegeEvaluator.isAllowed(request.contextPath, url, method, auth)
+	}
+
+	protected boolean isFallback(def attrs) {
+		boolean fallback = false
+		def o = attrs.remove("fallback")
+		if (o instanceof Boolean) {
+			fallback = o
+		} else {
+			if (o != null) {
+				try {
+					def str = o.toString()
+					if (str) {
+						fallback = Boolean.parseBoolean(str)
+					}
+				} catch(e){}
+			}
+		}
+		return fallback
 	}
 
 	private String determineUrl(Map urlAttributes) {

--- a/plugin/src/docs/helperClasses/securityTagLib.adoc
+++ b/plugin/src/docs/helperClasses/securityTagLib.adoc
@@ -248,3 +248,10 @@ To use access controls defined, for example, in the interceptUrlMap:
 ----
 <sec:link controller='myController' action='myAction'>My link text</sec:link>
 ----
+
+By default, nothing will be rendered if the specified expression evaluates to `false` or URL is not allowed. To render only the text that would have been linked, set the `fallback` attribute:
+[source,html]
+.Listing {counter:listing}. Example using `<sec:link fallback='true'>` without an expression
+----
+<sec:link controller='myController' action='myAction' fallback='true'>This text will display but won't be linked if the user doesn't have access</sec:link>
+----


### PR DESCRIPTION
In the case that a user doesn't have access to a particular link, allow the text that would have been linked to be displayed.