### PR TITLE
Change ROLE_USER to ROLE_ADMIN

### DIFF
--- a/plugin/src/docs/requestMappings.adoc
+++ b/plugin/src/docs/requestMappings.adoc
@@ -80,7 +80,7 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
 ]
 ----
 
-Now in addition to the default mappings, we require an authentication with `ROLE_USER` for any URL starting with `/user`, a "`fully authenticated`" authentication (i.e. an explicit login was performed without using remember-me) with `ROLE_USER` for any URL starting with `/admin`, and finally to access the URL `/thing/register` the user must be authenticated with any role(s) but must use a PUT request.
+Now in addition to the default mappings, we require an authentication with `ROLE_USER` for any URL starting with `/user`, a "`fully authenticated`" authentication (i.e. an explicit login was performed without using remember-me) with `ROLE_ADMIN` for any URL starting with `/admin`, and finally to access the URL `/thing/register` the user must be authenticated with any role(s) but must use a PUT request.
 ====
 
 This is needed when using annotations; if you use the `grails.plugin.springsecurity.interceptUrlMap` map in `application.groovy` you'll need to add these URLs too, and likewise when using `Requestmap` instances. If you don't use annotations, you must add rules for the login and logout controllers also. You can add Requestmaps manually, or in BootStrap.groovy, for example:


### PR DESCRIPTION
The example references ROLE_ADMIN, but the descriptive text accidentally referred to ROLE_USER.