### PR TITLE
Issue-575: UserPasswordEncoderListener not generated by s2-quickstart script in Grails 4

### DIFF
--- a/functional-test-app/build.gradle
+++ b/functional-test-app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "org.grails.plugins:hibernate5:${gormVersion-".RELEASE"}"
+        classpath "org.grails.plugins:hibernate5:${project.'gorm.version'-".RELEASE"}"
         classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
     }

--- a/functional-test-app/gradle.properties
+++ b/functional-test-app/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=4.0.0.RC1
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/integration-test-app/build.gradle
+++ b/integration-test-app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "org.grails.plugins:hibernate5:${gormVersion-".RELEASE"}"
+        classpath "org.grails.plugins:hibernate5:${project.'gorm.version'-".RELEASE"}"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
     }
 }

--- a/integration-test-app/gradle.properties
+++ b/integration-test-app/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=4.0.0.RC1
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/misc-functional-test-app/grails-spring-security-group/build.gradle
+++ b/misc-functional-test-app/grails-spring-security-group/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
-        classpath "org.grails.plugins:hibernate5:${gormVersion-".RELEASE"}"
+        classpath "org.grails.plugins:hibernate5:${project.'gorm.version'-".RELEASE"}"
         classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
 }

--- a/misc-functional-test-app/grails-spring-security-group/gradle.properties
+++ b/misc-functional-test-app/grails-spring-security-group/gradle.properties
@@ -1,3 +1,3 @@
 grailsVersion=4.0.0.RC1
 grailsWrapperVersion=1.0.0
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/misc-functional-test-app/grails-spring-security-hierarchical-roles/build.gradle
+++ b/misc-functional-test-app/grails-spring-security-hierarchical-roles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:$assetPipelineVersion"
-        classpath "org.grails.plugins:hibernate5:${gormVersion-".RELEASE"}"
+        classpath "org.grails.plugins:hibernate5:${project.'gorm.version'-".RELEASE"}"
         classpath "gradle.plugin.com.energizedwork.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
 
     }

--- a/misc-functional-test-app/grails-spring-security-hierarchical-roles/gradle.properties
+++ b/misc-functional-test-app/grails-spring-security-hierarchical-roles/gradle.properties
@@ -1,3 +1,3 @@
 grailsVersion=4.0.0.RC1
 grailsWrapperVersion=1.0.0
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/plugin/src/docs/code/s2-quickstart-requestmap/gradle.properties
+++ b/plugin/src/docs/code/s2-quickstart-requestmap/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=4.0.0.RC1
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/plugin/src/docs/code/s2-quickstart-rolegroup/gradle.properties
+++ b/plugin/src/docs/code/s2-quickstart-rolegroup/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=4.0.0.RC1
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/plugin/src/docs/code/s2-quickstart/gradle.properties
+++ b/plugin/src/docs/code/s2-quickstart/gradle.properties
@@ -1,2 +1,2 @@
 grailsVersion=4.0.0.RC1
-gormVersion=7.0.0.RC2
+gorm.version=7.0.0.RC2

--- a/plugin/src/main/scripts/s2-quickstart.groovy
+++ b/plugin/src/main/scripts/s2-quickstart.groovy
@@ -168,7 +168,7 @@ private void createDomains(Model userModel, Model roleModel, Model requestmapMod
 
 	final threshold = '6.0.10'
 
-	boolean gormVersionAfterThreshold = versionAfterOrEqualsToThreshold(threshold, props.gormVersion)
+	boolean gormVersionAfterThreshold = versionAfterOrEqualsToThreshold(threshold, props.gormVersion ?: props.getProperty("gorm.version"))
 
 	if ( gormVersionAfterThreshold ) {
 		generateFile 'PersonWithoutInjection', userModel.packagePath, userModel.simpleName


### PR DESCRIPTION
When a new grails 4 app is created, the GORM version is set in the `gradle.properties` file as follows:

```
gorm.version=7.0.1.RELEASE
```

This is different from pre grails 4 apps where the GORM version was set like the following:

```
gormVersion=6.1.9.RELEASE
```

Notice how the key used to define the GORM version has changed.

I've modified the `s2-quickstart` script as well as project files to support the new way of reference GORM version in grails 4 apps.

This PR is for issue #575 