### PR TITLE
Fix ReflectionUtils.findFilterChainNames

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
@@ -210,7 +210,7 @@ class ReflectionUtils {
 
 	static SortedMap<Integer, String> findFilterChainNames(ConfigObject conf) {
 		SpringSecurityUtils.findFilterChainNames conf.filterChain.filterNames,
-				conf.secureChannel.definition as boolean, conf.ipRestrictions as boolean, conf.useX509,
-				conf.useDigestAuth, conf.useBasicAuth, conf.useSwitchUserFilter
+				conf.secureChannel.definition as boolean, conf.ipRestrictions as boolean, conf.useX509 as boolean,
+				conf.useDigestAuth as boolean, conf.useBasicAuth as boolean, conf.useSwitchUserFilter as boolean
 	}
 }

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
@@ -147,4 +147,27 @@ class ReflectionUtilsSpec extends AbstractUnitSpec {
 		then:
 		ReflectionUtils.getGrailsServerURL() == null
 	}
+
+	void 'findFilterNames works with multiple boolean representations of settings'() {
+		when:
+		ConfigObject config = [
+				'filterChain.filterNames':'dummy',
+				'secureChannel.definition':secureChannelValue,
+				'ipRestrictions':ipRestrictionsValue,
+				'useX509':x509Value,
+				'useDigestAuth':digestAuthValue,
+				'useBasicAuth':basicAuthValue,
+				'useSwitchUserFilter':switchUserFilterValue
+								] as ConfigObject
+		ReflectionUtils.findFilterChainNames(config)
+
+		then:
+		noExceptionThrown()
+
+		where:
+		secureChannelValue | ipRestrictionsValue | x509Value | digestAuthValue | basicAuthValue | switchUserFilterValue
+		true			   | false				 | false	 | false		   | true			| false
+		'true'			   | 'false'			 | 'false'	 | 'false'		   | 'true'			| 'false'
+		true			   | 'false'			 | null	     | null		       | 'true'			| null
+	}
 }


### PR DESCRIPTION
Fix ReflectionUtils.findFilterChainNames when config values come from .properties file and need explicit boolean conversion.