### PR TITLE
Showcase thread inheritance pitfalls and include hint in documentation

### DIFF
--- a/plugin/src/docs/index.adoc
+++ b/plugin/src/docs/index.adoc
@@ -10,6 +10,8 @@ include::introduction.adoc[]
 
 include::newInV4.adoc[]
 
+include::newInV321.adoc[]
+
 include::newInV3.adoc[]
 
 include::newInV2.adoc[]

--- a/plugin/src/docs/newInV321.adoc
+++ b/plugin/src/docs/newInV321.adoc
@@ -3,6 +3,9 @@
 
 === Default SecurityContextHolder strategy
 
-Version 3.2.1 of the plugin now uses `"MODE_INHERITABLETHREADLOCAL"` as the default strategy. This means that newly created thread inherit the security context of the parent thread.
+Version 3.2.1 of the plugin now uses `"MODE_INHERITABLETHREADLOCAL"` as the default strategy. This means that newly created threads inherit the security context of the parent thread.
 
-NOTE: Beware when using thread pools. Threads keep the security context they inherit when the thread is created the first time. The context isn't updated when the thread is reused for a different task.
+[WARNING]
+====
+Beware when using thread pools. Threads keep the security context they inherit when the thread is created the first time. The context isn't updated when the thread is reused for a different task.
+====

--- a/plugin/src/docs/newInV321.adoc
+++ b/plugin/src/docs/newInV321.adoc
@@ -1,0 +1,8 @@
+[[newInV321]]
+== What's New in Version 3.2.1
+
+=== Default SecurityContextHolder strategy
+
+Version 3.2.1 of the plugin now uses `"MODE_INHERITABLETHREADLOCAL"` as the default strategy. This means that newly created thread inherit the security context of the parent thread.
+
+NOTE: Beware when using thread pools. Threads keep the security context they inherit when the thread is created the first time. The context isn't updated when the thread is reused for a different task.


### PR DESCRIPTION
In version 3.2.1 the default context holder strategy was changed to `MODE_INHERITABLETHREADLOCAL`.

The documentation still says that `MODE_THREADLOCAL` is the default in the "Whats new in 3.0" section. I think this is a pretty big change to go undocumented and would even argue that it isn't a sensible default.

I tried including a short section in the docs about the change but I'm not sure on which hierarchical level to add it. 

I also included two failing integration tests to showcase how easy it is to shoot yourself in the foot using a SecurityContextHolder that is shared between multiple threads. 

