### PR TITLE
Issue-588: Read messages from injected properties

### DIFF
--- a/integration-test-app/grails-app/conf/spring/resources.groovy
+++ b/integration-test-app/grails-app/conf/spring/resources.groovy
@@ -1,5 +1,8 @@
 import com.test.AdditionalLogoutHandler
+import grails.plugin.springsecurity.web.authentication.preauth.x509.ClosureX509PrincipalExtractor
 
 beans = {
 	additionalLogoutHandler(AdditionalLogoutHandler)
+
+	x509PrincipalExtractor(ClosureX509PrincipalExtractor)
 }

--- a/integration-test-app/grails-app/i18n/messages.properties
+++ b/integration-test-app/grails-app/i18n/messages.properties
@@ -1,0 +1,4 @@
+AbstractUserDetailsAuthenticationProvider.disabled=Custom user account is disabled.
+AbstractUserDetailsAuthenticationProvider.locked=Custom user account is locked.
+AbstractUserDetailsAuthenticationProvider.expired=Custom user account is expired.
+AbstractUserDetailsAuthenticationProvider.credentialsExpired=Custom user credentials are expired.

--- a/integration-test-app/grails-app/i18n/messages.properties
+++ b/integration-test-app/grails-app/i18n/messages.properties
@@ -2,3 +2,4 @@ AbstractUserDetailsAuthenticationProvider.disabled=Custom user account is disabl
 AbstractUserDetailsAuthenticationProvider.locked=Custom user account is locked.
 AbstractUserDetailsAuthenticationProvider.expired=Custom user account is expired.
 AbstractUserDetailsAuthenticationProvider.credentialsExpired=Custom user credentials are expired.
+SubjectDnX509PrincipalExtractor.noMatching=Subject not found: {0}

--- a/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/ClosureX509PrincipalExtractorSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/ClosureX509PrincipalExtractorSpec.groovy
@@ -1,0 +1,32 @@
+package grails.plugin.springsecurity
+
+import grails.plugin.springsecurity.web.authentication.preauth.x509.ClosureX509PrincipalExtractor
+import org.springframework.security.authentication.BadCredentialsException
+
+import java.security.Principal
+import java.security.cert.X509Certificate
+
+class ClosureX509PrincipalExtractorSpec extends AbstractIntegrationSpec {
+
+    ClosureX509PrincipalExtractor x509PrincipalExtractor
+
+    def setup() {
+        x509PrincipalExtractor.closure = { return null }
+    }
+
+    def 'x509 principal extractor exception uses i18n message'() {
+        given:
+        def clientCert = Mock(X509Certificate) {
+            getSubjectDN() >> Mock(Principal) {
+                getName() >> 'non-existent@example.com'
+            }
+        }
+
+        when:
+        x509PrincipalExtractor.extractPrincipal(clientCert)
+
+        then:
+        def exception = thrown(BadCredentialsException)
+        exception.message == 'Subject not found: non-existent@example.com'
+    }
+}

--- a/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/PrePostAuthenticationCheckSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/PrePostAuthenticationCheckSpec.groovy
@@ -1,0 +1,53 @@
+package grails.plugin.springsecurity
+
+
+import org.springframework.security.authentication.AccountExpiredException
+import org.springframework.security.authentication.CredentialsExpiredException
+import org.springframework.security.authentication.DisabledException
+import org.springframework.security.authentication.LockedException
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsChecker
+import spock.lang.Unroll
+
+class PrePostAuthenticationCheckSpec extends AbstractIntegrationSpec {
+
+    UserDetailsChecker preAuthenticationChecks
+    UserDetailsChecker postAuthenticationChecks
+
+    @Unroll
+    def 'pre-authentication exception uses i18n message - #test'() {
+        given:
+        def userDetails = Mock(UserDetails) {
+            isAccountNonLocked() >> { test != 'locked' }
+            isEnabled() >> { test != 'disabled' }
+            isAccountNonExpired() >> { test != 'expired'}
+        }
+
+        when:
+        preAuthenticationChecks.check(userDetails)
+
+        then:
+        Exception exception = thrown(type)
+        exception.message == expectMessage
+
+        where:
+        test       | type                    | expectMessage
+        'locked'   | LockedException         | 'Custom user account is locked.'
+        'disabled' | DisabledException       | 'Custom user account is disabled.'
+        'expired'  | AccountExpiredException | 'Custom user account is expired.'
+    }
+
+    def 'post-authentication exception uses i18n message - credentials expired'() {
+        given:
+        def userDetails = Mock(UserDetails) {
+            isCredentialsNonExpired() >> false
+        }
+
+        when:
+        postAuthenticationChecks.check(userDetails)
+
+        then:
+        Exception exception = thrown(CredentialsExpiredException)
+        exception.message == 'Custom user credentials are expired.'
+    }
+}

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/DefaultPostAuthenticationChecks.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/DefaultPostAuthenticationChecks.groovy
@@ -17,6 +17,8 @@ package grails.plugin.springsecurity.userdetails
 import groovy.util.logging.Slf4j
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.context.MessageSource
+import org.springframework.context.MessageSourceAware
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.security.authentication.CredentialsExpiredException
 import org.springframework.security.core.SpringSecurityMessageSource
@@ -33,9 +35,14 @@ import groovy.transform.CompileStatic
  */
 @Slf4j
 @CompileStatic
-class DefaultPostAuthenticationChecks implements UserDetailsChecker {
+class DefaultPostAuthenticationChecks implements UserDetailsChecker, MessageSourceAware {
 
 	protected MessageSourceAccessor messages = SpringSecurityMessageSource.accessor
+
+	@Override
+	void setMessageSource(MessageSource messageSource) {
+		this.messages = new MessageSourceAccessor(messageSource)
+	}
 
 	void check(UserDetails user) {
 		if (!user.credentialsNonExpired) {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/DefaultPreAuthenticationChecks.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/DefaultPreAuthenticationChecks.groovy
@@ -17,6 +17,8 @@ package grails.plugin.springsecurity.userdetails
 import groovy.util.logging.Slf4j
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.context.MessageSource
+import org.springframework.context.MessageSourceAware
 import org.springframework.context.support.MessageSourceAccessor
 import org.springframework.security.authentication.AccountExpiredException
 import org.springframework.security.authentication.DisabledException
@@ -35,9 +37,14 @@ import groovy.transform.CompileStatic
  */
 @Slf4j
 @CompileStatic
-class DefaultPreAuthenticationChecks implements UserDetailsChecker {
+class DefaultPreAuthenticationChecks implements UserDetailsChecker, MessageSourceAware {
 
 	protected MessageSourceAccessor messages = SpringSecurityMessageSource.accessor
+
+	@Override
+	void setMessageSource(MessageSource messageSource) {
+		this.messages = new MessageSourceAccessor(messageSource)
+	}
 
 	void check(UserDetails user) {
 		if (!user.accountNonLocked) {

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/web/authentication/preauth/x509/ClosureX509PrincipalExtractor.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/web/authentication/preauth/x509/ClosureX509PrincipalExtractor.groovy
@@ -15,6 +15,7 @@
 package grails.plugin.springsecurity.web.authentication.preauth.x509
 
 import groovy.util.logging.Slf4j
+import org.springframework.context.MessageSourceAware
 
 import java.security.cert.X509Certificate
 
@@ -33,7 +34,7 @@ import groovy.transform.CompileStatic
  */
 @Slf4j
 @CompileStatic
-class ClosureX509PrincipalExtractor implements X509PrincipalExtractor {
+class ClosureX509PrincipalExtractor implements X509PrincipalExtractor, MessageSourceAware {
 
 	protected MessageSourceAccessor messages = SpringSecurityMessageSource.accessor
 
@@ -60,6 +61,7 @@ class ClosureX509PrincipalExtractor implements X509PrincipalExtractor {
 	 * Dependency injection for the message source.
 	 * @param messageSource the message source
 	 */
+	@Override
 	void setMessageSource(MessageSource messageSource) {
 		messages = new MessageSourceAccessor(messageSource)
 	}


### PR DESCRIPTION
Fixes #588 

* Use MessageSourceAware interface in the Pre/post authentication checks, matching the functionality of AbstractUserDetailsAuthenticationProvider
* Apply similar fix to `ClosureX509PrincipalExtractor` since it had a similar issue
* Add integration tests to spec the behaviors

Note: I targetted 3.3.x so this fix can be applied there, but it should also be compatible with 4.0.x too.