### PR TITLE
Fix 'Could not find matching constructor ' error

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/ReflectionUtils.groovy
@@ -142,7 +142,7 @@ class ReflectionUtils {
 				tokens = [value.toString()]
 			}
 
-			def httpMethod = row.httpMethod
+			def httpMethod = row.httpMethod ?: null
 			if (httpMethod instanceof CharSequence) {
 				httpMethod = HttpMethod.valueOf(httpMethod)
 			}

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.groovy
@@ -53,14 +53,14 @@ enum SecurityFilterPosition {
 	REQUEST_CACHE_FILTER,
 	/** SecurityContextHolderAwareRequestFilter */
 	SERVLET_API_SUPPORT_FILTER,
+	/** Remember-me cookie */
+	REMEMBER_ME_FILTER,
 	/** Anonymous auth */
 	ANONYMOUS_FILTER,
 	/** SessionManagementFilter */
 	SESSION_MANAGEMENT_FILTER,
 	/** Spring HttpPutFormContentFilter allows www-url-form-encoded content-types to provide params in PUT requests */
 	HTTP_PUT_FORM_CONTENT_FILTER,
-	/** Remember-me cookie */
-	REMEMBER_ME_FILTER,
 	/** ExceptionTranslationFilter */
 	EXCEPTION_TRANSLATION_FILTER,
 	/** FilterSecurityInterceptor */

--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity
 
+
+import org.grails.config.NavigableMap
 import org.springframework.http.HttpMethod
 
 /**
@@ -147,4 +149,23 @@ class ReflectionUtilsSpec extends AbstractUnitSpec {
 		then:
 		ReflectionUtils.getGrailsServerURL() == null
 	}
+	
+    void 'get intercept url map with empty httpMethod config'() {
+        when:
+        List<Map<String, Object>> interceptUrlMap = [
+                [
+                        pattern   : '/secure/**',
+                        access    : ['IS_AUTHENTICATED_ANONYMOUSLY'],
+                        httpMethod: new NavigableMap.NullSafeNavigator(null, null) //This is the case with missing config.
+                ]
+        ]
+        List<InterceptedUrl> interceptedUrls = ReflectionUtils.splitMap(interceptUrlMap)
+
+        then:
+        notThrown(GroovyRuntimeException)
+        interceptedUrls?.size() == 1
+        interceptedUrls.first()?.pattern == '/secure/**'
+        interceptedUrls.first().configAttributes?.size() == 1
+        interceptedUrls.first().configAttributes.first().attribute == 'IS_AUTHENTICATED_ANONYMOUSLY'
+    }
 }


### PR DESCRIPTION
Fix `Could not find matching constructor ` error when httpMethod is not configured in intercept URL map.

Fixes #572, Fixes #591.