### PR TITLE
Making createUserDetails method public

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/GormUserDetailsService.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/userdetails/GormUserDetailsService.groovy
@@ -106,7 +106,7 @@ class GormUserDetailsService implements GrailsUserDetailsService {
 		authorities ?: [NO_ROLE]
 	}
 
-	protected UserDetails createUserDetails(user, Collection<GrantedAuthority> authorities) {
+	UserDetails createUserDetails(user, Collection<GrantedAuthority> authorities) {
 
 		def conf = SpringSecurityUtils.securityConfig
 


### PR DESCRIPTION
# Description

Making the method `createUserDetails` in `GormUserDetailsService` public will allow the developers to use it directly.

# Motivation

In some scenarios (mostly when extending the normal login), it is required to create the `GrailsUser` manually. So exposing this method allows one to call it without extending the class.