### PR TITLE
Use unambiguous setter method name

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
@@ -1013,7 +1013,7 @@ to default to 'Annotation'; setting value to 'Annotation'
 			defaultFailureUrl = conf.failureHandler.defaultFailureUrl //'/login/authfail?login_error=1'
 			useForward = conf.failureHandler.useForward // false
 			ajaxAuthenticationFailureUrl = conf.failureHandler.ajaxAuthFailUrl // '/login/authfail?ajax=true'
-			exceptionMappings = conf.failureHandler.exceptionMappings // []
+			exceptionMappingsList = conf.failureHandler.exceptionMappings // []
 			allowSessionCreation = conf.failureHandler.allowSessionCreation // true
 		}
 

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/web/authentication/AjaxAwareAuthenticationFailureHandler.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/web/authentication/AjaxAwareAuthenticationFailureHandler.groovy
@@ -58,6 +58,10 @@ class AjaxAwareAuthenticationFailureHandler extends ExceptionMappingAuthenticati
 		super.setExceptionMappings((Map)mappings.inject([:], { LinkedHashMap map, Map mapping -> map[mapping.exception] = mapping.url; map }))
 	}
 
+	void setExceptionMappingsList(List<Map<String, ?>> mappings) {
+		super.setExceptionMappings((Map)mappings.inject([:], { LinkedHashMap map, Map mapping -> map[mapping.exception] = mapping.url; map }))
+	}
+
 	void afterPropertiesSet() {
 		assert ajaxAuthenticationFailureUrl, 'ajaxAuthenticationFailureUrl is required'
 	}


### PR DESCRIPTION
This was a super minor bug, but it really grated me every time I saw it...

Adds an alternatively named bean setter that serves the exact same purpose, but will avoid tripping the GenericTypeAwarePropertyDescriptor "ambiguous property" warning by default. Also changes the default config names so spring will utilize the new setter by default.

Kept the original around so as to not break any custom defined AjaxAwareAuthenticationFailureHandler.

Fixes #459