### PR TITLE
Smart Execute Release Post Build Step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           COMMIT_NAME: Puneet Behl
           VERSION: ${{ steps.release_version.outputs.release_version }}
       - name: Run post-release
-        if: success()
+        if: steps.publish.outcome == 'success' && steps.docs.outcome == 'success' && success()
         uses: micronaut-projects/github-actions/post-release@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Customized the release workflow post release step to only execute when both publish and build docs are successful.