### PR TITLE
Remove VERSION from documentation landing page template as it's only …

### DIFF
--- a/plugin/src/docs/index.tmpl
+++ b/plugin/src/docs/index.tmpl
@@ -84,7 +84,7 @@ img {
 
 		<h2>Grails 6.x.x and beyond</h2>
         <ul>
-            <li><a href="/grails-spring-security-core/@VERSION@/index.html">User guide</a></li>
+            <li><a href="/grails-spring-security-core/6.0.x/index.html">User guide</a></li>
         </ul>
 
 		<h2>Grails 5.x.x and beyond</h2>


### PR DESCRIPTION
…replaced on releases, but docs are sometimes published without a release which results in broken links.