### PR TITLE
test(plugin): Remove deprecated usage of `NavigableMap.NullSafeNavigator`

### DIFF
--- a/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
+++ b/plugin/src/test/groovy/grails/plugin/springsecurity/ReflectionUtilsSpec.groovy
@@ -15,7 +15,6 @@
 package grails.plugin.springsecurity
 
 
-import org.grails.config.NavigableMap
 import org.springframework.http.HttpMethod
 
 /**
@@ -179,7 +178,7 @@ class ReflectionUtilsSpec extends AbstractUnitSpec {
                 [
                         pattern   : '/secure/**',
                         access    : ['IS_AUTHENTICATED_ANONYMOUSLY'],
-                        httpMethod: new NavigableMap.NullSafeNavigator(null, null) //This is the case with missing config.
+                        httpMethod: null //This is the case with missing config.
                 ]
         ]
         List<InterceptedUrl> interceptedUrls = ReflectionUtils.splitMap(interceptUrlMap)


### PR DESCRIPTION
- Related issue: https://github.com/grails/grails-core/issues/13385
