### PR TITLE
Make `SecurityFilterPosition` a public class

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.java
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityFilterPosition.java
@@ -1,4 +1,4 @@
-/* Copyright 2006-2016 the original author or authors.
+/* Copyright 2006-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@ package grails.plugin.springsecurity;
 
 /**
  * Stores the default order numbers of all Spring Security filters for use in configuration.
- *
+ * <p>
  * Equivalent to <code>org.springframework.security.config.http.SecurityFilters</code> which
  * unfortunately is package-default.
  *
  * @author Burt Beckwith
  */
-enum SecurityFilterPosition {
+public enum SecurityFilterPosition {
 
 	FIRST(Integer.MIN_VALUE),
 


### PR DESCRIPTION
This class was converted to Java from Groovy in 6ac0d9986be1594fc6a47cfa9e1e46b37adaa01a, and it was probably missed to add the `public` access modifier.

This caused a problem for the javadoc generation.