### PR TITLE
document how to avoid spring-security-core downgrade

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -9,6 +9,7 @@ def softwareVersion = SoftwareVersion.build(version.toString())
 def asciidoctorAttributes = [
         stableversion        : softwareVersion.stableVersion,
         snapshotversion      : softwareVersion.snapshotVersion,
+        springsecuritycoreversion : libs.versions.spring.security.get(),
         copyright            : 'Apache License, Version 2.0',
         docinfo1             : 'true',
         doctype              : 'book',

--- a/plugin/src/docs/introduction/configGroovy.adoc
+++ b/plugin/src/docs/introduction/configGroovy.adoc
@@ -26,5 +26,7 @@ dependencies {
     implementation 'org.grails.plugins:cxf:3.1.1'
     // CXF above security.
     implementation 'org.grails.plugins:spring-security-core:{stableversion}'
+    // required for Grails 6, since spring-boot-dependencies:2.7.18 downgrades
+    implementation 'org.springframework.security:spring-security-core:{springsecuritycoreversion}'
 }
 ----

--- a/plugin/src/docs/introduction/gettingStarted.adoc
+++ b/plugin/src/docs/introduction/gettingStarted.adoc
@@ -10,6 +10,8 @@ Begin by installing the Spring Security plugin into your Grails project. Add the
 [source,gradle,subs="+attributes"]
 ----
 implementation 'org.grails.plugins:spring-security-core:{stableversion}'
+// required for Grails 6, since spring-boot-dependencies:2.7.18 downgrades
+implementation 'org.springframework.security:spring-security-core:{springsecuritycoreversion}'
 ----
 
 .Step 2: Run the Initialization Script

--- a/plugin/src/docs/introduction/installation.adoc
+++ b/plugin/src/docs/introduction/installation.adoc
@@ -22,6 +22,8 @@ Ensure you have the following set up:
 dependencies {
     // ... other dependencies
     implementation 'org.grails.plugins:spring-security-core:{stableversion}'
+    // required for Grails 6, since spring-boot-dependencies:2.7.18 downgrades
+    implementation 'org.springframework.security:spring-security-core:{springsecuritycoreversion}'
 }
 ----
 +

--- a/plugin/src/docs/tutorials/usingControllerAnnotations.adoc
+++ b/plugin/src/docs/tutorials/usingControllerAnnotations.adoc
@@ -14,7 +14,9 @@ $ cd bookstore
 ----
 dependencies {
    ...
-   compile 'org.grails.plugins:spring-security-core:{project-version}'
+   implementation 'org.grails.plugins:spring-security-core:{project-version}'
+   // required for Grails 6, since spring-boot-dependencies:2.7.18 downgrades
+   implementation 'org.springframework.security:spring-security-core:{springsecuritycoreversion}'
    ...
 }
 ----


### PR DESCRIPTION
latest 6.1.2 build is showing spring security is downgraded,

```
+--- org.grails.plugins:spring-security-core:6.1.2
|   +--- org.grails:grails-core:6.2.2 (*)
|   +--- org.grails:grails-datastore-core:8.1.2 (*)
|   +--- org.grails:grails-datastore-gorm:8.1.2 (*)
|   +--- org.grails:grails-events-transform:5.0.2
|   +--- org.grails:grails-plugin-mimetypes:6.2.2 (*)
|   +--- org.grails.plugins:async:5.0.2
|   |   +--- org.grails:grails-async:5.0.2
|   |   \--- org.grails.plugins:events:5.0.2
|   |        +--- org.grails:grails-events:5.0.2
|   |        +--- org.grails:grails-events-compat:5.0.2
|   |        \--- org.grails:grails-events-transform:5.0.2
|   +--- org.grails:grails-web-common:6.2.2 (*)
|   +--- org.grails:grails-web-url-mappings:6.2.2 (*)
|   +--- org.springframework:spring-beans:5.3.39 (*)
|   +--- org.springframework:spring-context:5.3.39 (*)
|   +--- org.springframework:spring-expression:5.3.39 (*)
|   +--- org.springframework.security:spring-security-core:5.8.16 -> 5.7.11
|   |   +--- org.springframework.security:spring-security-crypto:5.7.11
|   |   +--- org.springframework:spring-aop:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-beans:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-context:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-core:5.3.29 -> 5.3.39 (*)
|   |   \--- org.springframework:spring-expression:5.3.29 -> 5.3.39 (*)
|   +--- org.springframework.security:spring-security-web:5.8.16 -> 5.7.11
|   |   +--- org.springframework.security:spring-security-core:5.7.11 (*)
|   |   +--- org.springframework:spring-core:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-aop:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-beans:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-context:5.3.29 -> 5.3.39 (*)
|   |   +--- org.springframework:spring-expression:5.3.29 -> 5.3.39 (*)
|   |   \--- org.springframework:spring-web:5.3.29 -> 5.3.39 (*)
|   \--- org.springframework:spring-web:5.3.39 (*)
+--- io.micronaut:micronaut-inject-groovy -> 3.10.4


org.springframework.security:spring-security-core:5.8.16 -> 5.7.11
```


org.springframework.boot:spring-boot-dependencies:2.7.18 is the cause