### PR TITLE
Update s2 quickstart to set hibernate-ehcache dependency

### DIFF
--- a/plugin/src/docs/code/s2-quickstart/build.gradle
+++ b/plugin/src/docs/code/s2-quickstart/build.gradle
@@ -43,7 +43,13 @@ dependencies {
     implementation "org.grails.plugins:async"
     implementation "org.grails.plugins:scaffolding"
     implementation "org.grails.plugins:hibernate5"
-    implementation "org.hibernate:hibernate-core:5.6.15.Final"
+    runtimeOnly "org.hibernate:hibernate-ehcache:$hibernateVersion", {
+        // exclude javax variant of hibernate-core
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+    runtimeOnly "org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec:$jbossTransactionApiVersion", {
+        // required for hibernate-ehcache to work with javax variant of hibernate-core excluded
+    }
     implementation "org.grails.plugins:events"
     implementation "org.grails.plugins:gsp"
     profile "org.grails.profiles:web"

--- a/plugin/src/docs/code/s2-quickstart/gradle.properties
+++ b/plugin/src/docs/code/s2-quickstart/gradle.properties
@@ -2,6 +2,8 @@ grailsVersion=5.2.5
 grailsGradlePluginVersion=6.1.2
 groovyVersion=3.0.11
 gorm.version=7.3.2
+hibernateVersion=5.6.15.Final
+jbossTransactionApiVersion=2.0.0.Final
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M


### PR DESCRIPTION
While excluding hibernate-core (javax) and including jboss-transaction-api