### PR TITLE
chore: adapt to new repo name

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thanks for reporting an issue for grails-spring-security-core. Please review the task list below before submitting the 
+Thanks for reporting an issue for grails-spring-security. Please review the task list below before submitting the 
 issue.
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Java CI](https://github.com/grails/grails-spring-security-core/actions/workflows/gradle.yml/badge.svg)](https://github.com/grails/grails-spring-security-core/actions/workflows/gradle.yml)
+[![Java CI](https://github.com/grails/grails-spring-security/actions/workflows/gradle.yml/badge.svg)](https://github.com/grails/grails-spring-security/actions/workflows/gradle.yml)
 
-Grails Spring Security Core Plugin
-==================================
+Grails Spring Security
+======================
 
-See [documentation](https://grails.github.io/grails-spring-security-core/latest/guide) for further information.
+See [documentation](https://grails.github.io/grails-spring-security/latest) for further information.
 
 ### Branch structure 
 

--- a/gradle/docs-config.gradle
+++ b/gradle/docs-config.gradle
@@ -13,7 +13,7 @@ dependencies {
 
 tasks.register('createReleaseDropDown', CreateReleaseDropDownTask) {
     group = 'documentation'
-    githubSlug = 'grails/grails-spring-security-core'
+    githubSlug = 'grails/grails-spring-security'
     currentVersion = version
     versions = docsVersionSelectorInclude.split(',').collect { it.strip() }
     index = layout.buildDirectory.file('docs/index.html')

--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -15,7 +15,7 @@ extensions.configure(GrailsPublishExtension) {
 
     // Explicit `it` is required here
     it.artifactId = project.property('publishArtifactId')
-    it.githubSlug = 'grails/grails-spring-security-core'
+    it.githubSlug = 'grails/grails-spring-security'
     it.license.name = 'Apache-2.0'
     it.title = project.property('pomTitle')
     it.desc = project.property('pomDescription')

--- a/plugin-acl/README.md
+++ b/plugin-acl/README.md
@@ -1,7 +1,7 @@
 Grails Spring Security ACL Plugin
 ==================================
 
-See [documentation](https://grails.github.io/grails-spring-security-core/latest/acl-plugin/guide) for further information.
+See [documentation](https://grails.github.io/grails-spring-security/latest/acl-plugin/guide) for further information.
 
 ## v5.0.0 changes
 

--- a/plugin-acl/docs/src/docs/introduction.adoc
+++ b/plugin-acl/docs/src/docs/introduction.adoc
@@ -1,7 +1,7 @@
 [[introduction]]
 == Introduction to the Spring Security ACL Plugin
 
-The ACL plugin adds Domain Object Security support to a Grails application that uses Spring Security. It depends on the https://github.com/grails/grails-spring-security-core[Spring Security Core plugin].
+The ACL plugin adds Domain Object Security support to a Grails application that uses Spring Security. It depends on the https://github.com/grails/grails-spring-security[Spring Security Core plugin].
 
 The core plugin and other extension plugins support restricting access to URLs via rules that include checking a user's authentication status, roles, etc. and the ACL plugin extends this by adding support for restricting access to individual domain class instances. The access can be very fine-grained and can define which actions can be taken on an object - these typically include Read, Create, Write, Delete, and Administer but you're free to define whatever actions you like.
 

--- a/plugin-acl/docs/src/docs/tutorial.adoc
+++ b/plugin-acl/docs/src/docs/tutorial.adoc
@@ -26,7 +26,7 @@ and run the `compile` command to resolve the dependencies:
 $ grails compile
 ....
 
-This will transitively install the https://github.com/grails/grails-spring-security-core[Spring Security Core] plugin, so you'll need to configure that by running the `s2-quickstart` script:
+This will transitively install the https://github.com/grails/grails-spring-security[Spring Security Core] plugin, so you'll need to configure that by running the `s2-quickstart` script:
 
 ....
 $ grails s2-quickstart com.testacl User Role

--- a/plugin-acl/plugin/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
+++ b/plugin-acl/plugin/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
@@ -89,11 +89,11 @@ class SpringSecurityAclGrailsPlugin extends Plugin {
 	String authorEmail = ''
 	String title = 'Spring Security ACL plugin'
 	String description = 'ACL support for the Spring Security plugin'
-	String documentation = 'https://grails.github.io/grails-spring-security-core'
+	String documentation = 'https://grails.github.io/grails-spring-security'
 	String license = 'APACHE'
 	def organization = [name: 'Grails', url: 'https://www.grails.org']
-	def issueManagement = [url: 'https://github.com/grails/grails-spring-security-core/issues']
-	def scm = [url: 'https://github.com/grails/grails-spring-security-core']
+	def issueManagement = [url: 'https://github.com/grails/grails-spring-security/issues']
+	def scm = [url: 'https://github.com/grails/grails-spring-security']
 	def loadAfter = ['springSecurityCore']
 	def profiles = ['web']
 

--- a/plugin-cas/README.md
+++ b/plugin-cas/README.md
@@ -1,5 +1,5 @@
 Grails Spring Security CAS Plugin
 ==================================
 
-See [documentation](https://grails.github.io/grails-spring-security-core/latest/cas-plugin/guide) for further information.
+See [documentation](https://grails.github.io/grails-spring-security/latest/cas-plugin/guide) for further information.
 

--- a/plugin-cas/plugin/src/main/groovy/grails/plugin/springsecurity/cas/SpringSecurityCasGrailsPlugin.groovy
+++ b/plugin-cas/plugin/src/main/groovy/grails/plugin/springsecurity/cas/SpringSecurityCasGrailsPlugin.groovy
@@ -42,12 +42,12 @@ class SpringSecurityCasGrailsPlugin extends Plugin {
 	String authorEmail = ''
 	String title = 'Jasig CAS support for the Spring Security plugin.'
 	String description = 'Jasig CAS support for the Spring Security plugin.'
-	String documentation = 'https://grails.github.io/grails-spring-security-core'
+	String documentation = 'https://grails.github.io/grails-spring-security'
 	String license = 'APACHE'
 	List loadAfter = ['springSecurityCore']
 	def organization = [name: 'Grails', url: 'https://www.grails.org']
-	def issueManagement = [url: 'https://github.com/grails/grails-spring-security-core/issues']
-	def scm = [url: 'https://github.com/grails/grails-spring-security-core']
+	def issueManagement = [url: 'https://github.com/grails/grails-spring-security/issues']
+	def scm = [url: 'https://github.com/grails/grails-spring-security']
 	def profiles = ['web']
 
 	@CompileDynamic

--- a/plugin-core/docs/src/docs/index.tmpl
+++ b/plugin-core/docs/src/docs/index.tmpl
@@ -59,7 +59,7 @@ img {
 </head>
 
 <body>
-	<a href="http://github.com/grails/grails-spring-security-core">
+	<a href="http://github.com/grails/grails-spring-security">
 		<img style="position: absolute; top: 0; right: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
 	</a>
 
@@ -78,34 +78,34 @@ img {
 
 		<h2>Spring Security Core Plugin - Documentation</h2>
 		<ul>
-			<li><a href="/grails-spring-security-core/snapshot/index.html">Documentation Snapshot</a></li>
-			<!-- <li><a href="/grails-spring-security-core/latest/index.html">Latest Documentation</a></li> -->
+			<li><a href="/grails-spring-security/snapshot/index.html">Documentation Snapshot</a></li>
+			<!-- <li><a href="/grails-spring-security/latest/index.html">Latest Documentation</a></li> -->
 		</ul>
 
 		<h2>Grails 6.x.x and beyond</h2>
         <ul>
-            <li><a href="/grails-spring-security-core/6.0.x/index.html">User guide</a></li>
+            <li><a href="/grails-spring-security/6.0.x/index.html">User guide</a></li>
         </ul>
 
 		<h2>Grails 5.x.x and beyond</h2>
 		<ul>
-			<li><a href="/grails-spring-security-core/5.3.x/index.html">User guide</a></li>
-			<li><a href="/grails-spring-security-core/5.3.x/spring-security-core.pdf">User guide PDF</a></li>
-			<li><a href="/grails-spring-security-core/5.3.x/spring-security-core.epub">User guide EPUB</a></li>
+			<li><a href="/grails-spring-security/5.3.x/index.html">User guide</a></li>
+			<li><a href="/grails-spring-security/5.3.x/spring-security-core.pdf">User guide PDF</a></li>
+			<li><a href="/grails-spring-security/5.3.x/spring-security-core.epub">User guide EPUB</a></li>
 		</ul>
 
 		<h2>Grails 4.0.x and beyond</h2>
 		<ul>
-			<li><a href="/grails-spring-security-core/4.0.x/index.html">User guide</a></li>
-			<li><a href="/grails-spring-security-core/4.0.x/spring-security-core.pdf">User guide PDF</a></li>
-			<li><a href="/grails-spring-security-core/4.0.x/spring-security-core.epub">User guide EPUB</a></li>
+			<li><a href="/grails-spring-security/4.0.x/index.html">User guide</a></li>
+			<li><a href="/grails-spring-security/4.0.x/spring-security-core.pdf">User guide PDF</a></li>
+			<li><a href="/grails-spring-security/4.0.x/spring-security-core.epub">User guide EPUB</a></li>
 		</ul>
 
 		<h2>Grails 3.x.x</h2>
 		<ul>
-			<li><a href="/grails-spring-security-core/3.2.x/index.html">User guide</a></li>
-			<li><a href="/grails-spring-security-core/3.2.x/spring-security-core.pdf">User guide PDF</a></li>
-			<li><a href="/grails-spring-security-core/3.2.x/spring-security-core.epub">User guide EPUB</a></li>
+			<li><a href="/grails-spring-security/3.2.x/index.html">User guide</a></li>
+			<li><a href="/grails-spring-security/3.2.x/spring-security-core.pdf">User guide PDF</a></li>
+			<li><a href="/grails-spring-security/3.2.x/spring-security-core.epub">User guide EPUB</a></li>
 		</ul>
 
 		<h2>Documentation (version 2.0.x)</h2>
@@ -117,10 +117,10 @@ img {
 		<hr />
 
 		<div class="download">
-			<a href="http://github.com/grails/grails-spring-security-core/zipball/master">
+			<a href="http://github.com/grails/grails-spring-security/zipball/master">
 				<img width="90" src="http://github.com/images/modules/download/zip.png">
 			</a>
-			<a href="http://github.com/grails/grails-spring-security-core/tarball/master">
+			<a href="http://github.com/grails/grails-spring-security/tarball/master">
 				<img width="90" src="http://github.com/images/modules/download/tar.png">
 			</a>
 		</div>
@@ -128,11 +128,11 @@ img {
 		<h2>Download Source</h2>
 		<p>
 			You can download this project in either
-			<a href="http://github.com/grails/grails-spring-security-core/zipball/master">zip</a> or
-			<a href="http://github.com/grails/grails-spring-security-core/tarball/master">tar</a> formats.
+			<a href="http://github.com/grails/grails-spring-security/zipball/master">zip</a> or
+			<a href="http://github.com/grails/grails-spring-security/tarball/master">tar</a> formats.
 		</p>
 		<p>You can also clone the project with <a href="http://git-scm.com">Git</a> by running:
-			<pre>$ git clone git://github.com/grails/grails-spring-security-core</pre>
+			<pre>$ git clone git://github.com/grails/grails-spring-security</pre>
 		</p>
 
   </div>

--- a/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
+++ b/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/CustomFilterRegistrationSpec.groovy
@@ -8,7 +8,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 @IgnoreIf({ System.getProperty('TESTCONFIG') != 'issue503' })
-@Issue('https://github.com/grails/grails-spring-security-core/issues/503')
+@Issue('https://github.com/grails/grails-spring-security/issues/503')
 @Integration(applicationClass = functional.test.app.Application)
 class CustomFilterRegistrationSpec extends HttpClientSpec {
 

--- a/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/MiscSpec.groovy
+++ b/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/MiscSpec.groovy
@@ -344,7 +344,7 @@ class MiscSpec extends AbstractHyphenatedSecuritySpec {
 		assertContentContains 'barFoo'
 	}
 
-	@Issue('https://github.com/grails/grails-spring-security-core/issues/414')
+	@Issue('https://github.com/grails/grails-spring-security/issues/414')
 	void 'test Servlet API methods unauthenticated'() {
 		when:
 		go 'misc-test/test-servlet-api-methods'
@@ -358,7 +358,7 @@ class MiscSpec extends AbstractHyphenatedSecuritySpec {
 		assertContentContains 'request.remoteUser: null'
 	}
 
-	@Issue('https://github.com/grails/grails-spring-security-core/issues/414')
+	@Issue('https://github.com/grails/grails-spring-security/issues/414')
 	void 'test Servlet API methods authenticated'() {
 		when:
 		login 'admin'
@@ -378,7 +378,7 @@ class MiscSpec extends AbstractHyphenatedSecuritySpec {
 		assertContentContains 'request.remoteUser: admin'
 	}
 
-	@Issue('https://github.com/grails/grails-spring-security-core/issues/403')
+	@Issue('https://github.com/grails/grails-spring-security/issues/403')
 	void 'test controller with annotated index action, unauthenticated'() {
 		when:
 		go 'index-annotated'
@@ -405,7 +405,7 @@ class MiscSpec extends AbstractHyphenatedSecuritySpec {
 		assertContentContains 'Please Login'
 	}
 
-	@Issue('https://github.com/grails/grails-spring-security-core/issues/403')
+	@Issue('https://github.com/grails/grails-spring-security/issues/403')
 	void 'test controller with annotated index action, authenticated'() {
 		when:
 		login 'admin'

--- a/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/TestFormParamsControllerSpec.groovy
+++ b/plugin-core/examples/functional-test-app/src/integration-test/groovy/specs/TestFormParamsControllerSpec.groovy
@@ -13,7 +13,7 @@ import spock.lang.Issue
 import spock.lang.Shared
 
 @IgnoreIf({ System.getProperty('TESTCONFIG') != 'putWithParams' })
-@Issue('https://github.com/grails/grails-spring-security-core/issues/554')
+@Issue('https://github.com/grails/grails-spring-security/issues/554')
 @Integration(applicationClass = Application)
 class TestFormParamsControllerSpec extends HttpClientSpec {
 

--- a/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
+++ b/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SpringSecurityCoreGrailsPlugin.groovy
@@ -157,11 +157,11 @@ class SpringSecurityCoreGrailsPlugin extends Plugin {
 	String authorEmail = ''
 	String title = 'Spring Security Core Plugin'
 	String description = 'Spring Security Core plugin'
-	String documentation = 'https://grails.github.io/grails-spring-security-core'
+	String documentation = 'https://grails.github.io/grails-spring-security'
 	String license = 'APACHE'
 	def organization = [name: 'Grails', url: 'https://www.grails.org']
-	def issueManagement = [url: 'https://github.com/grails/grails-spring-security-core/issues']
-	def scm = [url: 'https://github.com/grails/grails-spring-security-core']
+	def issueManagement = [url: 'https://github.com/grails/grails-spring-security/issues']
+	def scm = [url: 'https://github.com/grails/grails-spring-security']
 	def profiles = ['web']
 
 	private beanTypeResolver

--- a/plugin-ldap/README.md
+++ b/plugin-ldap/README.md
@@ -1,7 +1,7 @@
 Grails Spring Security LDAP Plugin
 ==================================
 
-See [documentation](https://grails.github.io/grails-spring-security-core/latest/ldap-plugin/guide) for further information.
+See [documentation](https://grails.github.io/grails-spring-security/latest/ldap-plugin/guide) for further information.
 
 
 ## What is LDAP?

--- a/plugin-ldap/docs/build.gradle
+++ b/plugin-ldap/docs/build.gradle
@@ -55,7 +55,7 @@ ext {
             idprefix                          : '',
             idseparator                       : '-',
             version                           : projectVersion,
-            projectUrl                        : 'https://github.com/grails/grails-spring-security-core',
+            projectUrl                        : 'https://github.com/grails/grails-spring-security',
             sourcedir                         : "${rootProject.findProject(':ldap-plugin').projectDir}/src/main/groovy",
             gormDetailedLink                  : "https://gorm.grails.org/${getGrailsDocumentationVersion(bomVersions.gorm)}/hibernate/manual/index.html",
             gormSummaryLink                   : "https://docs.grails.org/${getGrailsDocumentationVersion(grailsVersion)}/guide/GORM.html",
@@ -63,7 +63,7 @@ ext {
             functionalTestAppPath             : "${rootProject.findProject(':ldap-examples-functional-test-app').projectDir}",
             customUserDetailsContextMapperPath: "${rootProject.findProject(':ldap-examples-custom-user-details-context-mapper').projectDir}",
             grailsSpringSecurityCoreVersion   : projectVersion,
-            grailsSpringSecurityCoreLink      : "https://grails.github.io/grails-spring-security-core/${getGrailsDocumentationVersion(projectVersion)}/index.html",
+            grailsSpringSecurityCoreLink      : "https://grails.github.io/grails-spring-security/${getGrailsDocumentationVersion(projectVersion)}/index.html",
             springSecurityLdapLink            : "https://docs.spring.io/spring-security/reference/${bomVersions.springSecurity}/servlet/authentication/passwords/ldap.html",
             springSecurityLdapApiLink         : "https://docs.spring.io/spring-security/site/docs/${bomVersions.springSecurity}/api"
     ]

--- a/plugin-ldap/plugin/src/main/groovy/grails/plugin/springsecurity/ldap/SpringSecurityLdapGrailsPlugin.groovy
+++ b/plugin-ldap/plugin/src/main/groovy/grails/plugin/springsecurity/ldap/SpringSecurityLdapGrailsPlugin.groovy
@@ -45,11 +45,11 @@ class SpringSecurityLdapGrailsPlugin extends Plugin {
 	String authorEmail = ''
 	String title = 'LDAP authentication support for the Spring Security plugin.'
 	String description = 'LDAP authentication support for the Spring Security plugin.'
-	String documentation = 'https://grails.github.io/grails-spring-security-core'
+	String documentation = 'https://grails.github.io/grails-spring-security'
 	String license = 'APACHE'
 	def organization = [name: 'Grails', url: 'https://www.grails.org']
-	def issueManagement = [url: 'https://github.com/grails/grails-spring-security-core/issues']
-	def scm = [url: 'https://github.com/grails/grails-spring-security-core']
+	def issueManagement = [url: 'https://github.com/grails/grails-spring-security/issues']
+	def scm = [url: 'https://github.com/grails/grails-spring-security']
 
 	Closure doWithSpring() {{ ->
 

--- a/plugin-oauth2/README.md
+++ b/plugin-oauth2/README.md
@@ -10,7 +10,7 @@ Main differences with the Grails 2 plugin:
 
 Documentation
 ------------
-[User Guide](https://grails.github.io/grails-spring-security-core/latest/oauth2-plugin/guide)
+[User Guide](https://grails.github.io/grails-spring-security/latest/oauth2-plugin/guide)
 
 Installation
 ------------

--- a/plugin-rest/README.md
+++ b/plugin-rest/README.md
@@ -4,7 +4,7 @@ Spring Security REST for Grails
 Grails plugin to implement a stateless, token-based, RESTful authentication 
 using Spring Security.
 
-Documentation is available [here](https://grails.github.io/grails-spring-security-core/latest/rest-plugin/guide).
+Documentation is available [here](https://grails.github.io/grails-spring-security/latest/rest-plugin/guide).
 
 Branch Structure
 -------

--- a/plugin-rest/docs/build.gradle
+++ b/plugin-rest/docs/build.gradle
@@ -20,7 +20,7 @@ ext {
             'icons'           : 'font',
             'version'         : projectVersion,
             'sourcedir'       : "${rootProject.allprojects.find { it.name == 'spring-security-rest' }.projectDir}/src/main/groovy",
-            'baseGroovyApiUrl': "https://grails.github.io/grails-spring-security-core/rest-plugin/${projectVersion}/docs/gapi/"
+            'baseGroovyApiUrl': "https://grails.github.io/grails-spring-security/rest-plugin/${projectVersion}/docs/gapi/"
     ]
 }
 

--- a/plugin-rest/spring-security-rest-gorm/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGormGrailsPlugin.groovy
+++ b/plugin-rest/spring-security-rest-gorm/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGormGrailsPlugin.groovy
@@ -23,14 +23,14 @@ class SpringSecurityRestGormGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    String documentation = 'https://grails.github.io/grails-spring-security-core'
+    String documentation = 'https://grails.github.io/grails-spring-security'
 
     // Extra (optional) plugin metadata
     String license = 'APACHE'
     def organization = [name: 'Grails', url: 'https://www.grails.org/']
 
-    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security-core/issues']
-    def scm = [ url: 'https://github.com/grails/grails-spring-security-core']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security/issues']
+    def scm = [ url: 'https://github.com/grails/grails-spring-security']
 
     Closure doWithSpring() { {->
         def conf = SpringSecurityUtils.securityConfig

--- a/plugin-rest/spring-security-rest-grailscache/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsCacheGrailsPlugin.groovy
+++ b/plugin-rest/spring-security-rest-grailscache/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsCacheGrailsPlugin.groovy
@@ -23,14 +23,14 @@ class SpringSecurityRestGrailsCacheGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    String documentation = 'https://grails.github.io/grails-spring-security-core'
+    String documentation = 'https://grails.github.io/grails-spring-security'
 
     // Extra (optional) plugin metadata
     String license = 'APACHE'
     def organization = [name: 'Grails', url: 'https://www.grails.org']
 
-    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security-core/issues']
-    def scm = [ url: 'https://github.com/grails/grails-spring-security-core']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security/issues']
+    def scm = [ url: 'https://github.com/grails/grails-spring-security']
 
     Closure doWithSpring() { {->
         def conf = SpringSecurityUtils.securityConfig

--- a/plugin-rest/spring-security-rest-memcached/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestMemcachedGrailsPlugin.groovy
+++ b/plugin-rest/spring-security-rest-memcached/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestMemcachedGrailsPlugin.groovy
@@ -26,13 +26,13 @@ class SpringSecurityRestMemcachedGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    String documentation = 'https://grails.github.io/grails-spring-security-core'
+    String documentation = 'https://grails.github.io/grails-spring-security'
 
     // Extra (optional) plugin metadata
     String license = 'APACHE'
     def organization = [name: 'Grails', url: 'https://www.grails.org']
 
-    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security-core/issues']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security/issues']
     def scm = [ url: 'https://github.com/grails/grails-spring-security-rest']
 
     Closure doWithSpring() { {->

--- a/plugin-rest/spring-security-rest-redis/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestRedisGrailsPlugin.groovy
+++ b/plugin-rest/spring-security-rest-redis/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestRedisGrailsPlugin.groovy
@@ -23,14 +23,14 @@ class SpringSecurityRestRedisGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    String documentation = 'https://grails.github.io/grails-spring-security-core'
+    String documentation = 'https://grails.github.io/grails-spring-security'
 
     // Extra (optional) plugin metadata
     String license = 'APACHE'
     def organization = [name: 'Grails', url: 'https://www.grails.org']
 
-    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security-core/issues']
-    def scm = [ url: 'https://github.com/grails/grails-spring-security-core']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security/issues']
+    def scm = [ url: 'https://github.com/grails/grails-spring-security']
 
 
     Closure doWithSpring() { {->

--- a/plugin-rest/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
+++ b/plugin-rest/spring-security-rest/src/main/groovy/grails/plugin/springsecurity/rest/SpringSecurityRestGrailsPlugin.groovy
@@ -79,14 +79,14 @@ class SpringSecurityRestGrailsPlugin extends Plugin {
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    String documentation = 'https://grails.github.io/grails-spring-security-core'
+    String documentation = 'https://grails.github.io/grails-spring-security'
 
     // Extra (optional) plugin metadata
     String license = 'APACHE'
     def organization = [name: 'Grails', url: 'https://www.grails.org']
 
-    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security-core/issues']
-    def scm = [ url: 'https://github.com/grails/grails-spring-security-core']
+    def issueManagement = [system: 'GitHub', url: 'https://github.com/grails/grails-spring-security/issues']
+    def scm = [ url: 'https://github.com/grails/grails-spring-security']
     GrailsApplication grailsApplication
 
     Closure doWithSpring() { {->

--- a/plugin-ui/README.md
+++ b/plugin-ui/README.md
@@ -1,3 +1,3 @@
 # Grails Spring Security UI
 
-[Documentation](https://grails.github.io/grails-spring-security-core/latest/ui-plugin/guide)
+[Documentation](https://grails.github.io/grails-spring-security/latest/ui-plugin/guide)

--- a/plugin-ui/docs/src/docs/persistentCookie.adoc
+++ b/plugin-ui/docs/src/docs/persistentCookie.adoc
@@ -1,7 +1,7 @@
 [[persistentCookie]]
 == Persistent Cookie Management
 
-Persistent cookies aren't enabled by default - you must enable them by running the `s2-create-persistent-token` script. See the https://grails.github.io/grails-spring-security-core/latest/index.html#rememberMeCookie[Spring Security Core Plugin documentation] for details about this feature.
+Persistent cookies aren't enabled by default - you must enable them by running the `s2-create-persistent-token` script. See the https://grails.github.io/grails-spring-security/latest/index.html#rememberMeCookie[Spring Security Core Plugin documentation] for details about this feature.
 
 The Persistent Logins menu is only shown if this feature is enabled.
 

--- a/plugin-ui/plugin/src/main/groovy/grails/plugin/springsecurity/ui/SpringSecurityUiGrailsPlugin.groovy
+++ b/plugin-ui/plugin/src/main/groovy/grails/plugin/springsecurity/ui/SpringSecurityUiGrailsPlugin.groovy
@@ -39,11 +39,11 @@ class SpringSecurityUiGrailsPlugin extends Plugin {
 	String authorEmail = ''
 	String title = 'Spring Security UI plugin'
 	String description = 'User interface extensions for the Spring Security plugin'
-	String documentation = 'https://grails.github.io/grails-spring-security-core'
+	String documentation = 'https://grails.github.io/grails-spring-security'
 	String license = 'APACHE'
 	def organization = [name: 'Grails', url: 'https://www.grails.org']
-	def issueManagement = [url: 'https://github.com/grails/grails-spring-security-core/issues']
-	def scm = [url: 'https://github.com/grails/grails-spring-security-core']
+	def issueManagement = [url: 'https://github.com/grails/grails-spring-security/issues']
+	def scm = [url: 'https://github.com/grails/grails-spring-security']
 	def loadAfter = ['springSecurityCore', 'springSecurityAcl']
 	def profiles = ['web']
 


### PR DESCRIPTION
Repository was renamed from `grails-spring-security-core` to `grails-spring-security`.