### PR TITLE
build: remove workaround for `asset-pipeline`

### DIFF
--- a/gradle/examples-config.gradle
+++ b/gradle/examples-config.gradle
@@ -2,13 +2,6 @@ tasks.withType(Groovydoc).configureEach {
     enabled = false
 }
 
-tasks.named('bootJar') {
-    // Workaround for:
-    // Execution failed for task ':core-examples-functional-test-app:bootJar'.
-    // > Entry BOOT-INF/lib/grails-web-databinding-7.0.0-SNAPSHOT.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/8.12.1/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
-    enabled = false
-}
-
 tasks.matching { 'assetCompile' == it.name }.configureEach {
     // Workaround for: https://github.com/bertramdev/asset-pipeline/issues/177
     // Execution failed for task ':cas-examples-spring-security-cas-test1:assetCompile'.


### PR DESCRIPTION
`asset-pipeline` 5.0.9 has been released with Grails at Apache coordinates.