### PR TITLE
fix gradle build error for plugin-rest/spring-security-rest-testapp-profile

### DIFF
--- a/plugin-rest/spring-security-rest-testapp-profile/build.gradle
+++ b/plugin-rest/spring-security-rest-testapp-profile/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'groovy'
     id 'org.apache.grails.gradle.grails-profile'
 }
 


### PR DESCRIPTION
This fixes a Gradle error that I see when building locally:
```
* What went wrong:
A problem occurred configuring project ':spring-security-rest-testapp-profile'.
> Grails Publish Plugin requires the Java Plugin to be applied to the project.
```
