### PR TITLE
Update ghpages.html to include links to documentation for all 7 plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,13 @@ Grails Spring Security
 
 See [documentation](https://apache.github.io/grails-spring-security/latest/ghpages.html) for detailed information.
 
-[core-plugin](https://apache.github.io/grails-spring-security/latest/core-plugin/guide/)
-
-[rest-plugin](https://apache.github.io/grails-spring-security/latest/rest-plugin/guide/)
-
-[ui-plugin](https://apache.github.io/grails-spring-security/latest/ui-plugin/guide/)
-
-[acl-plugin](https://apache.github.io/grails-spring-security/latest/acl-plugin/guide/)
-
-[ldap-plugin](https://apache.github.io/grails-spring-security/latest/ldap-plugin/guide/)
-
-[cas-plugin](https://apache.github.io/grails-spring-security/latest/cas-plugin/guide/)
-
-[oauth2-plugin](https://apache.github.io/grails-spring-security/latest/oauth2-plugin/guide/)
+- [CORE](https://apache.github.io/grails-spring-security/latest/core-plugin/guide/)
+  - [ACL](https://apache.github.io/grails-spring-security/latest/acl-plugin/guide/)
+  - [CAS](https://apache.github.io/grails-spring-security/latest/cas-plugin/guide/)
+  - [LDAP](https://apache.github.io/grails-spring-security/latest/ldap-plugin/guide/)
+  - [OAuth2](https://apache.github.io/grails-spring-security/latest/oauth2-plugin/guide/)
+  - [REST](https://apache.github.io/grails-spring-security/latest/rest-plugin/guide/)
+  - [UI](https://apache.github.io/grails-spring-security/latest/ui-plugin/guide/)
 
 ### Building
 

--- a/plugin-core/docs/src/docs/index.tmpl
+++ b/plugin-core/docs/src/docs/index.tmpl
@@ -88,15 +88,27 @@ img {
 
 		<hr />
 
-		<h2>Spring Security Core Plugin - Documentation</h2>
+		<h2>Spring Security Core Plugin - Documentation SNAPSHOTS</h2>
 		<ul>
-			<li><a href="/grails-spring-security/snapshot/core-plugin/guide/index.html">Documentation Snapshot</a></li>
-			<!-- <li><a href="/grails-spring-security/latest/core-plugin/guide/index.html">Latest Documentation</a></li> -->
+			<li><a href="/grails-spring-security/snapshot/core-plugin/guide/index.html">core-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/rest-plugin/guide/index.html">rest-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/ui-plugin/guide/index.html">ui-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/acl-plugin/guide/index.html">acl-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/ldap-plugin/guide/index.html">ldap-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/cas-plugin/guide/index.html">cas-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/oauth2-plugin/guide/index.html">oauth2-plugin Snapshot User guide</a></li>
 		</ul>
 
 		<h2>Grails 7.x.x and beyond</h2>
         <ul>
-            <li><a href="/grails-spring-security/7.0.x/core-plugin/guide/index.html">User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/core-plugin/guide/index.html">core-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/rest-plugin/guide/index.html">rest-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/ui-plugin/guide/index.html">ui-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/acl-plugin/guide/index.html">acl-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/ldap-plugin/guide/index.html">ldap-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/cas-plugin/guide/index.html">cas-plugin User guide</a></li>
+            <li><a href="/grails-spring-security/7.0.x/oauth2-plugin/guide/index.html">oauth2-plugin User guide</a></li>
+
         </ul>
 
 		<h2>Grails 6.x.x</h2>

--- a/plugin-core/docs/src/docs/index.tmpl
+++ b/plugin-core/docs/src/docs/index.tmpl
@@ -24,7 +24,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-<title>Grails Spring Security Plugin</title>
+<title>Grails Spring Security Plugins Documentation</title>
 
 <style type="text/css">
 body {

--- a/plugin-core/docs/src/docs/index.tmpl
+++ b/plugin-core/docs/src/docs/index.tmpl
@@ -24,7 +24,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-<title>Grails Spring Security Core Plugin</title>
+<title>Grails Spring Security Plugin</title>
 
 <style type="text/css">
 body {
@@ -84,31 +84,34 @@ img {
 	</a>
 
 	<div id="container">
-		<h1>Grails Spring Security Core Plugin</h1>
+		<h1>Grails Spring Security Plugins - Documentation</h1>
 
 		<hr />
 
-		<h2>Spring Security Core Plugin - Documentation SNAPSHOTS</h2>
+		<h2>User Guides - SNAPSHOTS</h2>
 		<ul>
-			<li><a href="/grails-spring-security/snapshot/core-plugin/guide/index.html">core-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/rest-plugin/guide/index.html">rest-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/ui-plugin/guide/index.html">ui-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/acl-plugin/guide/index.html">acl-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/ldap-plugin/guide/index.html">ldap-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/cas-plugin/guide/index.html">cas-plugin Snapshot User guide</a></li>
-			<li><a href="/grails-spring-security/snapshot/oauth2-plugin/guide/index.html">oauth2-plugin Snapshot User guide</a></li>
+			<li><a href="/grails-spring-security/snapshot/core-plugin/guide/index.html">Core</a></li>
+			<ul>
+			    <li><a href="/grails-spring-security/snapshot/acl-plugin/guide/index.html">ACL</a></li>
+                <li><a href="/grails-spring-security/snapshot/cas-plugin/guide/index.html">CAS</a></li>
+                <li><a href="/grails-spring-security/snapshot/ldap-plugin/guide/index.html">LDAP</a></li>
+                <li><a href="/grails-spring-security/snapshot/oauth2-plugin/guide/index.html">OAuth2</a></li>
+                <li><a href="/grails-spring-security/snapshot/rest-plugin/guide/index.html">REST</a></li>
+                <li><a href="/grails-spring-security/snapshot/ui-plugin/guide/index.html">UI</a></li>
+            </ul>
 		</ul>
 
-		<h2>Grails 7.x.x and beyond</h2>
+		<h2>User Guides - Grails 7 and beyond</h2>
         <ul>
-            <li><a href="/grails-spring-security/7.0.x/core-plugin/guide/index.html">core-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/rest-plugin/guide/index.html">rest-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/ui-plugin/guide/index.html">ui-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/acl-plugin/guide/index.html">acl-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/ldap-plugin/guide/index.html">ldap-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/cas-plugin/guide/index.html">cas-plugin User guide</a></li>
-            <li><a href="/grails-spring-security/7.0.x/oauth2-plugin/guide/index.html">oauth2-plugin User guide</a></li>
-
+            <li><a href="/grails-spring-security/snapshot/core-plugin/guide/index.html">Core</a></li>
+            <ul>
+                <li><a href="/grails-spring-security/7.0.x/acl-plugin/guide/index.html">ACL</a></li>
+                <li><a href="/grails-spring-security/7.0.x/cas-plugin/guide/index.html">CAS</a></li>
+                <li><a href="/grails-spring-security/7.0.x/ldap-plugin/guide/index.html">LDAP</a></li>
+                <li><a href="/grails-spring-security/7.0.x/oauth2-plugin/guide/index.html">OAuth2</a></li>
+                <li><a href="/grails-spring-security/7.0.x/rest-plugin/guide/index.html">REST</a></li>
+                <li><a href="/grails-spring-security/7.0.x/ui-plugin/guide/index.html">UI</a></li>
+            </ul>
         </ul>
 
 		<h2>Grails 6.x.x</h2>


### PR DESCRIPTION
Updates https://apache.github.io/grails-spring-security/latest/ghpages.html to link to documentation for all 7 plugins