### PR TITLE
[skip ci] chore: add actions permission to allow merges of releases that update a workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
       contents: write # required for gradle.properties revert
       issues: write # required for milestone closing
       pull-requests: write # to open PR
+      actions: write
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the failed release merge https://github.com/apache/grails-spring-security/actions/runs/16486104828/job/47265490785 in future releases