### PR TITLE
throw a more descriptive exception when required CAS configuration values are not set

### DIFF
--- a/plugin-cas/plugin/src/main/groovy/grails/plugin/springsecurity/cas/SpringSecurityCasGrailsPlugin.groovy
+++ b/plugin-cas/plugin/src/main/groovy/grails/plugin/springsecurity/cas/SpringSecurityCasGrailsPlugin.groovy
@@ -76,6 +76,12 @@ class SpringSecurityCasGrailsPlugin extends Plugin {
 			println '\nConfiguring Spring Security CAS ...'
 		}
 
+		['serverUrlPrefix', 'loginUri', 'serviceUrl'].each { requiredConfigKey ->
+			if (!conf.cas[requiredConfigKey]) {
+				throw new IllegalStateException("cas.${requiredConfigKey} is not set: this is a required configuration value when cas.active is true")
+			}
+		}
+
 		if (conf.cas.useSingleSignout) {
 
 			// session fixation prevention breaks single signout because


### PR DESCRIPTION
This addresses issue #1079 where a NullPointerException is getting thrown when required values are not configured.  The NullPointerException is not clear what is wrong.  This will throw a more descriptive exception that indicates which required configuration values are not set.