### PR TITLE
Update documentation and commands to use ./grailsw instead of ./gradlew

### DIFF
--- a/plugin-core/docs/src/docs/hierarchicalRoles.adoc
+++ b/plugin-core/docs/src/docs/hierarchicalRoles.adoc
@@ -90,7 +90,7 @@ For example, running
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry"
+./grailsw s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry
 ----
 
 will generate this class in `grails-app/domain/com/yourapp/RoleHierarchyEntry.groovy`:

--- a/plugin-core/docs/src/docs/introduction/installation.adoc
+++ b/plugin-core/docs/src/docs/introduction/installation.adoc
@@ -69,7 +69,7 @@ dependencies {
 +
 [source,bash]
 ```
-./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role"
+./grailsw s2-quickstart s2-quickstart com.yourapp User Role
 ```
 
 === Verifying Installation

--- a/plugin-core/docs/src/docs/scripts/s2-create-persistent-token.adoc
+++ b/plugin-core/docs/src/docs/scripts/s2-create-persistent-token.adoc
@@ -26,14 +26,14 @@ Creates a persistent token domain class for storing remember-me cookie informati
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-create-persistent-token <classname>"
+./grailsw s2-create-persistent-token <classname>
 ----
 
 .Example
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-create-persistent-token com.yourapp.PersistentLogin"
+./grailsw s2-create-persistent-token com.yourapp.PersistentLogin
 ----
 
 .Description

--- a/plugin-core/docs/src/docs/scripts/s2-create-role-hierarchy-entry.adoc
+++ b/plugin-core/docs/src/docs/scripts/s2-create-role-hierarchy-entry.adoc
@@ -26,14 +26,14 @@ Creates a persistent role hierarchy entry domain class for storing role hierarch
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry <classname>"
+./grailsw s2-create-role-hierarchy-entry <classname>
 ----
 
 .Example
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry"
+./grailsw s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry
 ----
 
 .Description

--- a/plugin-core/docs/src/docs/scripts/s2-quickstart.adoc
+++ b/plugin-core/docs/src/docs/scripts/s2-quickstart.adoc
@@ -30,29 +30,29 @@ The general format is:
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart DOMAIN_CLASS_PACKAGE USER_CLASS_NAME ROLE_CLASS_NAME [REQUESTMAP_CLASS_NAME] [--groupClassName=GROUP_CLASS_NAME]"
+./grailsw s2-quickstart DOMAIN_CLASS_PACKAGE USER_CLASS_NAME ROLE_CLASS_NAME [REQUESTMAP_CLASS_NAME] [--groupClassName=GROUP_CLASS_NAME]
 ----
 
 .Examples
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role"
+./grailsw s2-quickstart s2-quickstart com.yourapp User Role
 ----
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role --groupClassName=RoleGroup"
+./grailsw s2-quickstart com.yourapp User Role --groupClassName=RoleGroup
 ----
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart com.yourapp Person Authority Requestmap"
+./grailsw s2-quickstart com.yourapp Person Authority Requestmap
 ----
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart --uiOnly"
+./grailsw s2-quickstart --uiOnly
 ----
 
 .Description

--- a/plugin-core/docs/src/docs/tutorials/usingControllerAnnotations.adoc
+++ b/plugin-core/docs/src/docs/tutorials/usingControllerAnnotations.adoc
@@ -48,7 +48,7 @@ $ grails compile
 
 [source,bash]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart com.mycompany.myapp User Role"
+./grailsw s2-quickstart com.mycompany.myapp User Role
 ----
 
 You can choose your names for your domain classes and package; these are just examples.

--- a/plugin-core/docs/src/docs/whatsNew.adoc
+++ b/plugin-core/docs/src/docs/whatsNew.adoc
@@ -32,7 +32,7 @@ One of the notable improvements is the seamless transition to Grails 6. The plug
 
 [source,shell]
 ----
-./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role"
+./grailsw s2-quickstart s2-quickstart com.yourapp User Role
 ----
 
 This aligns perfectly with Grails 6's development landscape, making your application's migration smoother than ever before.

--- a/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2CreatePersistentTokenCommand.groovy
+++ b/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2CreatePersistentTokenCommand.groovy
@@ -23,9 +23,9 @@ import groovy.transform.CompileStatic
 
 /**
  * Creates a persistent token domain class for the Spring Security Core plugin.
- * Usage: <code>./gradlew runCommand "-Pargs=s2-create-persistent-token [DOMAIN CLASS NAME]"</code>
+ * Usage: <code>./grailsw s2-create-persistent-token [DOMAIN CLASS NAME]</code>
 *
- * For example: <code>./gradlew runCommand "-Pargs=s2-create-persistent-token com.yourapp.PersistentLogin"</code>
+ * For example: <code>./grailsw s2-create-persistent-token com.yourapp.PersistentLogin</code>
  *
  * @author Puneet Behl
  * @since 6.0.0
@@ -37,9 +37,9 @@ class S2CreatePersistentTokenCommand implements GrailsApplicationCommand, Comman
     ConsoleLogger consoleLogger = GrailsConsole.getInstance()
 
     private final static USAGE_MESSAGE = '''
-./gradlew runCommand "-Pargs=s2-create-persistent-token [DOMAIN CLASS NAME]"
+./grailsw s2-create-persistent-token [DOMAIN CLASS NAME]
 
-For example: ./gradlew runCommand "-Pargs=s2-create-persistent-token com.yourapp.PersistentLogin"
+For example: ./grailsw s2-create-persistent-token com.yourapp.PersistentLogin
 '''
 
     @Override

--- a/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2CreateRoleHierarchyEntryCommand.groovy
+++ b/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2CreateRoleHierarchyEntryCommand.groovy
@@ -23,8 +23,8 @@ import groovy.transform.CompileStatic
 
 /**
  * Creates a domain class for a persistent role hierarchy for the Spring Security Core plugin
- * Usage: <code>./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry [DOMAIN CLASS NAME]"
- * For example: <code>./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry"</code>
+ * Usage: <code>./grailsw s2-create-role-hierarchy-entry [DOMAIN CLASS NAME]
+ * For example: <code>./grailsw s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry</code>
  *
  * @author Puneet Behl
  * @since 6.0.0
@@ -33,9 +33,9 @@ import groovy.transform.CompileStatic
 class S2CreateRoleHierarchyEntryCommand implements GrailsApplicationCommand, CommandLineHelper, SkipBootstrap {
 
     private static final String USAGE_MESSAGE = '''
-./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry [DOMAIN CLASS NAME]" 
+./grailsw s2-create-role-hierarchy-entry [DOMAIN CLASS NAME] 
  
- For example: ./gradlew runCommand "-Pargs=s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry"
+ For example: ./grailsw s2-create-role-hierarchy-entry com.yourapp.RoleHierarchyEntry
 '''
 
     @Delegate

--- a/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2QuickstartCommand.groovy
+++ b/plugin-core/plugin/grails-app/commands/grails.plugin.springsecurity/S2QuickstartCommand.groovy
@@ -23,14 +23,14 @@ import groovy.transform.CompileStatic
 
 /**
  * Creates domain classes and updates config settings for the Spring Security plugin.
- * Usage: <code>./gradlew runCommand "-Pargs=s2-quickstart [DOMAIN_CLASS_PACKAGE] [USER_CLASS_NAME] [ROLE_CLASS_NAME] [REQUEST_MAP_CLASS_NAME] --groupClassName=[GROUP_CLASS_NAME]"</code> or
+ * Usage: <code>./grailsw s2-quickstart [DOMAIN_CLASS_PACKAGE] [USER_CLASS_NAME] [ROLE_CLASS_NAME] [REQUEST_MAP_CLASS_NAME] --groupClassName=[GROUP_CLASS_NAME]</code> or
  * <code>s2-quickstart --ui-only</code>
  *
  * For Example:
- * 1. <code>./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role --groupClassName=RoleGroup"</code>
- * 2. <code>./gradlew runCommand "-Pargs=s2-quickstart com.yourapp Person Authority Requestmap"</code>
- * 3. <code>./gradlew runCommand "-Pargs=s2-quickstart --uiOnly"</code>
- * 4. <code>./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role"</code>
+ * 1. <code>./grailsw s2-quickstart com.yourapp User Role --groupClassName=RoleGroup</code>
+ * 2. <code>./grailsw s2-quickstart com.yourapp Person Authority Requestmap</code>
+ * 3. <code>./grailsw s2-quickstart --uiOnly</code>
+ * 4. <code>./grailsw s2-quickstart s2-quickstart com.yourapp User Role</code>
  *
  * @author Puneet Behl
  * @since 6.0.0
@@ -51,13 +51,13 @@ class S2QuickstartCommand implements GrailsApplicationCommand, CommandLineHelper
     String description = 'Creates domain classes and updates config settings for the Spring Security plugin.'
 
     private final static String USAGE_MESSAGE = '''
-   ./gradlew runCommand "-Pargs=s2-quickstart [DOMAIN-CLASS-PACKAGE] [USER-CLASS-NAME] [ROLE-CLASS-NAME] [REQUESTMAP-CLASS-NAME] --groupClassName=GROUP-CLASS-NAME"
-or ./gradlew runCommand "-Pargs=s2-quickstart --uiOnly"
+   ./grailsw s2-quickstart [DOMAIN-CLASS-PACKAGE] [USER-CLASS-NAME] [ROLE-CLASS-NAME] [REQUESTMAP-CLASS-NAME] --groupClassName=GROUP-CLASS-NAME
+or ./grailsw s2-quickstart --uiOnly
 
-Example: ./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role"
-Example: ./gradlew runCommand "-Pargs=s2-quickstart com.yourapp User Role --groupClassName=RoleGroup"
-Example: ./gradlew runCommand "-Pargs=s2-quickstart com.yourapp Person Authority Requestmap"
-Example: ./gradlew runCommand "-Pargs=s2-quickstart --uiOnly"
+Example: ./grailsw s2-quickstart s2-quickstart com.yourapp User Role
+Example: ./grailsw s2-quickstart com.yourapp User Role --groupClassName=RoleGroup
+Example: ./grailsw s2-quickstart com.yourapp Person Authority Requestmap
+Example: ./grailsw s2-quickstart --uiOnly
 '''
 
     @Delegate


### PR DESCRIPTION
Grails shell was restored in Grails 6.2.1 and these commands are simpler with `./grailsw` syntax vs `./gradlew` task syntax.  There is at least one bug in the s2 gradle tasks and that will be deferred until Grails 8.

Replaces usage of `./gradlew runCommand "-Pargs=..."` with `./grailsw ...` in documentation and command usage messages for consistency with Grails 5 conventions.

Partially addresses https://github.com/apache/grails-spring-security/issues/1172, the rest will wait for Grails 8.