### PR TITLE
#1195 - fix for broken doc link

### DIFF
--- a/plugin-rest/docs/src/docs/index.adoc
+++ b/plugin-rest/docs/src/docs/index.adoc
@@ -27,9 +27,9 @@ under the License.
 
 include::introduction.adoc[]
 
-== What's new in 6.0?
+== What's new in 6.0?z
 
-include:whatsNew60.adoc[]
+include::whatsNew60.adoc[]
 
 == What's new in 5.0?
 

--- a/plugin-rest/docs/src/docs/index.adoc
+++ b/plugin-rest/docs/src/docs/index.adoc
@@ -27,7 +27,7 @@ under the License.
 
 include::introduction.adoc[]
 
-== What's new in 6.0?z
+== What's new in 6.0?
 
 include::whatsNew60.adoc[]
 


### PR DESCRIPTION
Fix the What's new in 6.0 section for Spring Security Rest.