### PR TITLE
Auto-exclude conflicting Spring Boot security auto-configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,21 @@ Then publish the jar files to mavenLocal for usage:
 - `3.3.x` compatible with Grails 3.3.x
 - `3.2.x` compatible with Grails 3.2.x
 
-Grails 7 requires disabling any Spring Security Auto Configurations you may have in your classpath.  This can be done via annotation or `application.yml`
-e.g.
+### Spring Boot Auto-Configuration
+
+The plugin automatically excludes 7 Spring Boot security auto-configuration classes that conflict with the Grails Spring Security plugin. No manual `spring.autoconfigure.exclude` entries are needed.
+
+To disable this automatic exclusion (e.g. if you want to use Spring Boot's security auto-configuration directly), add the following to `application.yml`:
+
+```yml
+grails:
+  plugin:
+    springsecurity:
+      excludeSpringSecurityAutoConfiguration: false
+```
+
+If you are on an older version of the plugin that does not support automatic exclusion, you can manually exclude the conflicting classes:
+
 ```yml
 spring:
   autoconfigure:

--- a/plugin-core/docs/src/docs/introduction/installation.adoc
+++ b/plugin-core/docs/src/docs/introduction/installation.adoc
@@ -72,6 +72,20 @@ dependencies {
 ./grailsw s2-quickstart com.yourapp User Role
 ```
 
+=== Spring Boot Auto-Configuration
+
+The plugin automatically excludes Spring Boot security auto-configuration classes (such as `SecurityAutoConfiguration`, `SecurityFilterAutoConfiguration`, and `UserDetailsServiceAutoConfiguration`) that conflict with the plugin's own security setup. This means you do not need to manually add `spring.autoconfigure.exclude` entries to your `application.yml`.
+
+If you need to disable this automatic exclusion - for example, to use Spring Boot's security auto-configuration directly alongside the plugin - set the following property in `application.yml`:
+
+[source,yaml]
+----
+grails:
+  plugin:
+    springsecurity:
+      excludeSpringSecurityAutoConfiguration: false
+----
+
 === Verifying Installation
 
 To verify that the plugin has been successfully installed, you can run a simple test:

--- a/plugin-core/docs/src/docs/miscProperties.adoc
+++ b/plugin-core/docs/src/docs/miscProperties.adoc
@@ -129,4 +129,8 @@ under the License.
 |`true`
 |Whether to remove the password from the `Authentication` and its child objects after successful authentication
 
+|excludeSpringSecurityAutoConfiguration
+|`true`
+|Whether to automatically exclude Spring Boot security auto-configuration classes that conflict with the plugin. Set to `false` to allow Spring Boot's security auto-configurations to load alongside the plugin. See <<installation>>
+
 |====================

--- a/plugin-core/examples/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderIntegrationSpec.groovy
+++ b/plugin-core/examples/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderIntegrationSpec.groovy
@@ -18,14 +18,16 @@
  */
 package grails.plugin.springsecurity
 
-import grails.testing.mixin.integration.Integration
+import spock.lang.Specification
+
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.web.SecurityFilterChain
-import spock.lang.Specification
 
-@Integration(applicationClass = integration.test.app.Application)
+import grails.testing.mixin.integration.Integration
+
+@Integration
 class SecurityAutoConfigurationExcluderIntegrationSpec extends Specification {
 
     @Autowired
@@ -33,28 +35,37 @@ class SecurityAutoConfigurationExcluderIntegrationSpec extends Specification {
 
     void "SecurityAutoConfigurationExcluder class is on the classpath"() {
         expect:
-        Class.forName('grails.plugin.springsecurity.SecurityAutoConfigurationExcluder')
+        Class.forName(
+                'grails.plugin.springsecurity.SecurityAutoConfigurationExcluder'
+        )
     }
 
     void "SecurityAutoConfiguration bean is not registered"() {
         given:
-        Class secAutoConfig = Class.forName('org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration')
+        def secAutoConfig = Class.forName(
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration'
+        )
 
         expect:
-        applicationContext.getBeanNamesForType(secAutoConfig).length == 0
+        applicationContext
+                .getBeanNamesForType(secAutoConfig).length == 0
     }
 
     void "SecurityFilterAutoConfiguration bean is not registered"() {
         given:
-        Class secFilterAutoConfig = Class.forName('org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration')
+        def secFilterAutoConfig = Class.forName(
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration'
+        )
 
         expect:
-        applicationContext.getBeanNamesForType(secFilterAutoConfig).length == 0
+        applicationContext
+                .getBeanNamesForType(secFilterAutoConfig).length == 0
     }
 
     void "no duplicate SecurityFilterChain beans from auto-configuration"() {
         given:
-        String[] filterChainBeans = applicationContext.getBeanNamesForType(SecurityFilterChain)
+        def filterChainBeans = applicationContext
+                .getBeanNamesForType(SecurityFilterChain)
 
         expect:
         filterChainBeans.length <= 1
@@ -62,7 +73,8 @@ class SecurityAutoConfigurationExcluderIntegrationSpec extends Specification {
 
     void "only the plugin UserDetailsService is registered"() {
         given:
-        String[] udsBeans = applicationContext.getBeanNamesForType(UserDetailsService)
+        def udsBeans = applicationContext
+                .getBeanNamesForType(UserDetailsService)
 
         expect:
         udsBeans.length >= 1

--- a/plugin-core/examples/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderIntegrationSpec.groovy
+++ b/plugin-core/examples/integration-test-app/src/integration-test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderIntegrationSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.springsecurity
+
+import grails.testing.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationContext
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.web.SecurityFilterChain
+import spock.lang.Specification
+
+@Integration(applicationClass = integration.test.app.Application)
+class SecurityAutoConfigurationExcluderIntegrationSpec extends Specification {
+
+    @Autowired
+    ApplicationContext applicationContext
+
+    void "SecurityAutoConfigurationExcluder class is on the classpath"() {
+        expect:
+        Class.forName('grails.plugin.springsecurity.SecurityAutoConfigurationExcluder')
+    }
+
+    void "SecurityAutoConfiguration bean is not registered"() {
+        given:
+        Class secAutoConfig = Class.forName('org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration')
+
+        expect:
+        applicationContext.getBeanNamesForType(secAutoConfig).length == 0
+    }
+
+    void "SecurityFilterAutoConfiguration bean is not registered"() {
+        given:
+        Class secFilterAutoConfig = Class.forName('org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration')
+
+        expect:
+        applicationContext.getBeanNamesForType(secFilterAutoConfig).length == 0
+    }
+
+    void "no duplicate SecurityFilterChain beans from auto-configuration"() {
+        given:
+        String[] filterChainBeans = applicationContext.getBeanNamesForType(SecurityFilterChain)
+
+        expect:
+        filterChainBeans.length <= 1
+    }
+
+    void "only the plugin UserDetailsService is registered"() {
+        given:
+        String[] udsBeans = applicationContext.getBeanNamesForType(UserDetailsService)
+
+        expect:
+        udsBeans.length >= 1
+        udsBeans.any { it.contains('userDetailsService') }
+    }
+}

--- a/plugin-core/plugin/build.gradle
+++ b/plugin-core/plugin/build.gradle
@@ -43,51 +43,50 @@ dependencies {
 
 	implementation platform("org.apache.grails:grails-bom:$grailsVersion")
 
-	compileOnly 'org.apache.grails:grails-core' // Provided as this is a Grails Plugin
+	api 'org.apache.grails:grails-async' // AsyncGrailsWebRequest is used in public API
+	api 'org.apache.grails:grails-mimetypes'
 	api 'org.apache.grails.data:grails-datastore-core' // API because used in templates
 	api 'org.apache.grails.data:grails-datamapping-core' // API because used in templates
 	api 'org.apache.grails.events:grails-events-transforms' // API because used in templates
-	api 'org.apache.grails:grails-mimetypes'
-	api 'org.apache.grails:grails-async' // AsyncGrailsWebRequest is used in public API
 	api 'org.apache.grails.web:grails-web-common'
 	api 'org.apache.grails.web:grails-web-url-mappings'
 	api 'org.springframework:spring-beans'
 	api 'org.springframework:spring-context'
-	api 'org.springframework:spring-context'
+	api 'org.springframework:spring-web'
 	api 'org.springframework.security:spring-security-core'
 	api 'org.springframework.security:spring-security-web'
-	api 'org.springframework:spring-web'
 
 	implementation 'org.apache.commons:commons-text'
-	implementation "org.ehcache:ehcache", {
+	implementation 'org.ehcache:ehcache', {
         capabilities {
             requireCapability('org.ehcache:ehcache-jakarta')
         }
     }
-	implementation 'org.apache.grails.bootstrap:grails-bootstrap'
-	implementation 'org.apache.grails:grails-rest-transforms'
 	implementation 'org.apache.grails:grails-converters'
 	implementation 'org.apache.grails:grails-events' // Events Plugin is required to implement EventBus
-	implementation 'org.springframework.boot:spring-boot'
+	implementation 'org.apache.grails:grails-rest-transforms'
+	implementation 'org.apache.grails.bootstrap:grails-bootstrap'
 	implementation 'org.springframework:spring-context-support'
 	implementation 'org.springframework:spring-core'
-	implementation 'org.springframework.security:spring-security-crypto'
 	implementation 'org.springframework:spring-tx'
+	implementation 'org.springframework.boot:spring-boot'
+	implementation 'org.springframework.security:spring-security-crypto'
 
-	compileOnly 'jline:jline' // for shell commands
-	compileOnly 'org.apache.groovy:groovy' // Compile-time annotations
 	compileOnly 'jakarta.servlet:jakarta.servlet-api' // Provided
-	compileOnly 'org.springframework.boot:spring-boot-autoconfigure' // AutoConfigurationImportFilter SPI
+	compileOnly 'jline:jline' // for shell commands
+	compileOnly 'org.apache.grails:grails-core' // Provided as this is a Grails Plugin
+	compileOnly 'org.apache.groovy:groovy' // Compile-time annotations
 	compileOnly 'org.slf4j:slf4j-nop' // Prevents warnings about missing slf4j implementation during compilation
+	compileOnly 'org.springframework.boot:spring-boot-autoconfigure' // AutoConfigurationImportFilter SPI
 
 	runtimeOnly 'org.apache.grails:grails-services' // A service is defined in the plugin
 
 	testImplementation 'org.apache.grails:grails-testing-support-datamapping'
 	testImplementation 'org.apache.grails:grails-testing-support-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.spockframework:spock-core'
 	testImplementation 'org.springframework:spring-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-config'
+	testImplementation 'org.spockframework:spock-core'
 
 	testRuntimeOnly 'net.bytebuddy:byte-buddy'
 	testRuntimeOnly 'org.slf4j:slf4j-nop' // Prevents warnings about missing slf4j implementation during tests

--- a/plugin-core/plugin/build.gradle
+++ b/plugin-core/plugin/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 	compileOnly 'jline:jline' // for shell commands
 	compileOnly 'org.apache.groovy:groovy' // Compile-time annotations
 	compileOnly 'jakarta.servlet:jakarta.servlet-api' // Provided
+	compileOnly 'org.springframework.boot:spring-boot-autoconfigure' // AutoConfigurationImportFilter SPI
 	compileOnly 'org.slf4j:slf4j-nop' // Prevents warnings about missing slf4j implementation during compilation
 
 	runtimeOnly 'org.apache.grails:grails-services' // A service is defined in the plugin

--- a/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
+++ b/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.springsecurity
 
 import groovy.transform.CompileStatic
+
 import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter
 import org.springframework.boot.autoconfigure.AutoConfigurationMetadata
 import org.springframework.context.EnvironmentAware
@@ -101,15 +102,13 @@ class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter
             'org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration',
             'org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration',
             'org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration',
-    ] as Set<String>
+    ].toSet().asImmutable()
 
     @Override
     boolean[] match(String[] autoConfigurationClasses, AutoConfigurationMetadata autoConfigurationMetadata) {
-        boolean[] matches = new boolean[autoConfigurationClasses.length]
-        for (int i = 0; i < autoConfigurationClasses.length; i++) {
-            matches[i] = !enabled || !EXCLUDED_AUTO_CONFIGURATIONS.contains(autoConfigurationClasses[i])
-        }
-        return matches
+        autoConfigurationClasses.collect {
+            !enabled || !(it in EXCLUDED_AUTO_CONFIGURATIONS)
+        } as boolean[]
     }
 
     /**
@@ -119,6 +118,6 @@ class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter
      * @return unmodifiable set of excluded class names
      */
     static Set<String> getExcludedAutoConfigurations() {
-        return Collections.unmodifiableSet(EXCLUDED_AUTO_CONFIGURATIONS)
+        EXCLUDED_AUTO_CONFIGURATIONS
     }
 }

--- a/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
+++ b/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
@@ -1,0 +1,103 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.springsecurity
+
+import groovy.transform.CompileStatic
+import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter
+import org.springframework.boot.autoconfigure.AutoConfigurationMetadata
+
+/**
+ * Automatically excludes Spring Boot security auto-configuration classes that
+ * conflict with the Grails Spring Security plugin.
+ *
+ * <p>When the Grails Spring Security plugin is on the classpath, Spring Boot's
+ * security auto-configurations (e.g. {@code SecurityAutoConfiguration},
+ * {@code SecurityFilterAutoConfiguration}) create duplicate
+ * {@code SecurityFilterChain} beans and other security infrastructure that
+ * conflicts with the plugin's own bean definitions in
+ * {@link SpringSecurityCoreGrailsPlugin#doWithSpring}.</p>
+ *
+ * <p>Previously, users had to manually exclude up to 7 auto-configuration classes
+ * in {@code application.yml}. This filter removes that requirement by
+ * automatically filtering them out during Spring Boot's auto-configuration
+ * discovery phase.</p>
+ *
+ * <p>Registered via {@code META-INF/spring.factories} as an
+ * {@link AutoConfigurationImportFilter}. This runs before auto-configuration
+ * bytecode is loaded, so there is no performance overhead from excluded classes.</p>
+ *
+ * @since 7.0.2
+ * @see AutoConfigurationImportFilter
+ */
+@CompileStatic
+class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter {
+
+    /**
+     * Spring Boot security auto-configuration classes that conflict with the
+     * Grails Spring Security plugin. These are excluded unconditionally when the
+     * plugin is on the classpath.
+     *
+     * <ul>
+     *   <li>{@code SecurityAutoConfiguration} — creates a default {@code SecurityFilterChain}
+     *       that conflicts with the plugin's {@code FilterChainProxy}</li>
+     *   <li>{@code SecurityFilterAutoConfiguration} — registers a
+     *       {@code DelegatingFilterProxyRegistrationBean} that duplicates the plugin's
+     *       {@code springSecurityFilterChainRegistrationBean}</li>
+     *   <li>{@code UserDetailsServiceAutoConfiguration} — creates an in-memory
+     *       {@code UserDetailsService} that conflicts with the plugin's
+     *       {@code GormUserDetailsService}</li>
+     *   <li>{@code OAuth2ClientAutoConfiguration} ({@code ...oauth2.client.servlet}) —
+     *       conflicts when the plugin-oauth2 module manages OAuth2 configuration</li>
+     *   <li>{@code OAuth2ClientAutoConfiguration} ({@code ...oauth2.client}) —
+     *       non-servlet variant of the above; also conflicts with plugin-oauth2</li>
+     *   <li>{@code OAuth2ResourceServerAutoConfiguration} — conflicts with the
+     *       plugin's resource server security setup</li>
+     *   <li>{@code ManagementWebSecurityAutoConfiguration} — Actuator security
+     *       that conflicts when Actuator is on the classpath</li>
+     * </ul>
+     */
+    private static final Set<String> EXCLUDED_AUTO_CONFIGURATIONS = [
+            'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+            'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration',
+            'org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration',
+            'org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration',
+            'org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration',
+            'org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration',
+            'org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration',
+    ] as Set<String>
+
+    @Override
+    boolean[] match(String[] autoConfigurationClasses, AutoConfigurationMetadata autoConfigurationMetadata) {
+        boolean[] matches = new boolean[autoConfigurationClasses.length]
+        for (int i = 0; i < autoConfigurationClasses.length; i++) {
+            matches[i] = !EXCLUDED_AUTO_CONFIGURATIONS.contains(autoConfigurationClasses[i])
+        }
+        return matches
+    }
+
+    /**
+     * Returns the set of auto-configuration class names that this filter excludes.
+     * Exposed for testing and diagnostic purposes.
+     *
+     * @return unmodifiable set of excluded class names
+     */
+    static Set<String> getExcludedAutoConfigurations() {
+        return Collections.unmodifiableSet(EXCLUDED_AUTO_CONFIGURATIONS)
+    }
+}

--- a/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
+++ b/plugin-core/plugin/src/main/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluder.groovy
@@ -21,6 +21,8 @@ package grails.plugin.springsecurity
 import groovy.transform.CompileStatic
 import org.springframework.boot.autoconfigure.AutoConfigurationImportFilter
 import org.springframework.boot.autoconfigure.AutoConfigurationMetadata
+import org.springframework.context.EnvironmentAware
+import org.springframework.core.env.Environment
 
 /**
  * Automatically excludes Spring Boot security auto-configuration classes that
@@ -38,6 +40,16 @@ import org.springframework.boot.autoconfigure.AutoConfigurationMetadata
  * automatically filtering them out during Spring Boot's auto-configuration
  * discovery phase.</p>
  *
+ * <p>To disable this filter and allow Spring Boot's security auto-configurations
+ * to run, set the following property in {@code application.yml}:</p>
+ *
+ * <pre>
+ * grails:
+ *   plugin:
+ *     springsecurity:
+ *       excludeSpringSecurityAutoConfiguration: false
+ * </pre>
+ *
  * <p>Registered via {@code META-INF/spring.factories} as an
  * {@link AutoConfigurationImportFilter}. This runs before auto-configuration
  * bytecode is loaded, so there is no performance overhead from excluded classes.</p>
@@ -46,7 +58,16 @@ import org.springframework.boot.autoconfigure.AutoConfigurationMetadata
  * @see AutoConfigurationImportFilter
  */
 @CompileStatic
-class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter {
+class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter, EnvironmentAware {
+
+    static final String ENABLED_PROPERTY = 'grails.plugin.springsecurity.excludeSpringSecurityAutoConfiguration'
+
+    private boolean enabled = true
+
+    @Override
+    void setEnvironment(Environment environment) {
+        this.enabled = environment.getProperty(ENABLED_PROPERTY, Boolean, true)
+    }
 
     /**
      * Spring Boot security auto-configuration classes that conflict with the
@@ -86,7 +107,7 @@ class SecurityAutoConfigurationExcluder implements AutoConfigurationImportFilter
     boolean[] match(String[] autoConfigurationClasses, AutoConfigurationMetadata autoConfigurationMetadata) {
         boolean[] matches = new boolean[autoConfigurationClasses.length]
         for (int i = 0; i < autoConfigurationClasses.length; i++) {
-            matches[i] = !EXCLUDED_AUTO_CONFIGURATIONS.contains(autoConfigurationClasses[i])
+            matches[i] = !enabled || !EXCLUDED_AUTO_CONFIGURATIONS.contains(autoConfigurationClasses[i])
         }
         return matches
     }

--- a/plugin-core/plugin/src/main/resources/META-INF/spring.factories
+++ b/plugin-core/plugin/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Automatically exclude Spring Boot security auto-configurations that conflict
+# with the Grails Spring Security plugin's bean definitions.
+# See: SecurityAutoConfigurationExcluder javadoc for the full list and rationale.
+org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
+  grails.plugin.springsecurity.SecurityAutoConfigurationExcluder

--- a/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
+++ b/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
@@ -18,10 +18,11 @@
  */
 package grails.plugin.springsecurity
 
-import org.springframework.core.env.Environment
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
+
+import org.springframework.core.env.Environment
 
 /**
  * Tests for {@link SecurityAutoConfigurationExcluder}.
@@ -38,10 +39,10 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
     @Unroll
     def "match excludes conflicting auto-configuration: #className"() {
         given:
-        String[] autoConfigs = [className] as String[]
+        def autoConfigs = [className] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'the conflicting auto-configuration is excluded (false = filtered out)'
         !results[0]
@@ -61,10 +62,10 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
     @Unroll
     def "match preserves non-security auto-configuration: #className"() {
         given:
-        String[] autoConfigs = [className] as String[]
+        def autoConfigs = [className] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'non-security auto-configurations pass through (true = included)'
         results[0]
@@ -81,7 +82,7 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match handles mixed array of included and excluded auto-configurations"() {
         given:
-        String[] autoConfigs = [
+        def autoConfigs = [
                 'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
                 'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration',
@@ -90,7 +91,7 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
         ] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then:
         results[0]  // DataSource — included
@@ -102,10 +103,10 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match handles empty array"() {
         given:
-        String[] autoConfigs = [] as String[]
+        def autoConfigs = [] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then:
         results.length == 0
@@ -113,12 +114,12 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match handles null metadata parameter gracefully"() {
         given: 'autoConfigurationMetadata is null (not used by this filter)'
-        String[] autoConfigs = [
+        def autoConfigs = [
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
         ] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'still works correctly'
         !results[0]
@@ -126,7 +127,7 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "getExcludedAutoConfigurations returns all 7 known conflicting classes"() {
         when:
-        Set<String> excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
+        def excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
 
         then:
         excluded.size() == 7
@@ -141,7 +142,7 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "getExcludedAutoConfigurations returns unmodifiable set"() {
         when:
-        Set<String> excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
+        def excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
         excluded.add('some.new.AutoConfiguration')
 
         then:
@@ -150,19 +151,19 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match allows all auto-configurations when disabled via environment property"() {
         given:
-        Environment env = Mock(Environment)
+        def env = Mock(Environment)
         env.getProperty(SecurityAutoConfigurationExcluder.ENABLED_PROPERTY, Boolean, true) >> false
-        excluder.setEnvironment(env)
+        excluder.environment = env
 
         and:
-        String[] autoConfigs = [
+        def autoConfigs = [
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration',
                 'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
         ] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'all auto-configurations pass through when filter is disabled'
         results[0]
@@ -172,17 +173,17 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match excludes by default when environment has no property set"() {
         given:
-        Environment env = Mock(Environment)
+        def env = Mock(Environment)
         env.getProperty(SecurityAutoConfigurationExcluder.ENABLED_PROPERTY, Boolean, true) >> true
-        excluder.setEnvironment(env)
+        excluder.environment = env
 
         and:
-        String[] autoConfigs = [
+        def autoConfigs = [
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
         ] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'exclusion is active by default'
         !results[0]
@@ -190,12 +191,12 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "match excludes by default when no environment is set"() {
         given: 'excluder without environment (e.g. unit test usage)'
-        String[] autoConfigs = [
+        def autoConfigs = [
                 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
         ] as String[]
 
         when:
-        boolean[] results = excluder.match(autoConfigs, null)
+        def results = excluder.match(autoConfigs, null)
 
         then: 'exclusion is active by default'
         !results[0]
@@ -203,14 +204,14 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
     def "spring.factories registers the filter correctly"() {
         when: 'enumerating all spring.factories resources on the classpath'
-        Enumeration<URL> resources = getClass().getClassLoader().getResources('META-INF/spring.factories')
-        List<String> allContents = Collections.list(resources).collect { it.text }
+        def resources = getClass().classLoader.getResources('META-INF/spring.factories')
+        def allContents = resources.collect { it.text }
 
         then: 'at least one spring.factories exists'
         !allContents.isEmpty()
 
         and: 'one of them registers SecurityAutoConfigurationExcluder as an AutoConfigurationImportFilter'
-        allContents.any { String content ->
+        allContents.any { content ->
             content.contains('org.springframework.boot.autoconfigure.AutoConfigurationImportFilter') &&
                 content.contains('grails.plugin.springsecurity.SecurityAutoConfigurationExcluder')
         }

--- a/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
+++ b/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
@@ -18,6 +18,7 @@
  */
 package grails.plugin.springsecurity
 
+import org.springframework.core.env.Environment
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -145,6 +146,59 @@ class SecurityAutoConfigurationExcluderSpec extends Specification {
 
         then:
         thrown(UnsupportedOperationException)
+    }
+
+    def "match allows all auto-configurations when disabled via environment property"() {
+        given:
+        Environment env = Mock(Environment)
+        env.getProperty(SecurityAutoConfigurationExcluder.ENABLED_PROPERTY, Boolean, true) >> false
+        excluder.setEnvironment(env)
+
+        and:
+        String[] autoConfigs = [
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration',
+                'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
+        ] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'all auto-configurations pass through when filter is disabled'
+        results[0]
+        results[1]
+        results[2]
+    }
+
+    def "match excludes by default when environment has no property set"() {
+        given:
+        Environment env = Mock(Environment)
+        env.getProperty(SecurityAutoConfigurationExcluder.ENABLED_PROPERTY, Boolean, true) >> true
+        excluder.setEnvironment(env)
+
+        and:
+        String[] autoConfigs = [
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+        ] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'exclusion is active by default'
+        !results[0]
+    }
+
+    def "match excludes by default when no environment is set"() {
+        given: 'excluder without environment (e.g. unit test usage)'
+        String[] autoConfigs = [
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+        ] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'exclusion is active by default'
+        !results[0]
     }
 
     def "spring.factories registers the filter correctly"() {

--- a/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
+++ b/plugin-core/plugin/src/test/groovy/grails/plugin/springsecurity/SecurityAutoConfigurationExcluderSpec.groovy
@@ -1,0 +1,164 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.springsecurity
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+/**
+ * Tests for {@link SecurityAutoConfigurationExcluder}.
+ *
+ * Verifies that Spring Boot security auto-configuration classes that conflict
+ * with the Grails Spring Security plugin are filtered out during the
+ * auto-configuration discovery phase.
+ */
+class SecurityAutoConfigurationExcluderSpec extends Specification {
+
+    @Subject
+    SecurityAutoConfigurationExcluder excluder = new SecurityAutoConfigurationExcluder()
+
+    @Unroll
+    def "match excludes conflicting auto-configuration: #className"() {
+        given:
+        String[] autoConfigs = [className] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'the conflicting auto-configuration is excluded (false = filtered out)'
+        !results[0]
+
+        where:
+        className << [
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration',
+                'org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration',
+        ]
+    }
+
+    @Unroll
+    def "match preserves non-security auto-configuration: #className"() {
+        given:
+        String[] autoConfigs = [className] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'non-security auto-configurations pass through (true = included)'
+        results[0]
+
+        where:
+        className << [
+                'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
+                'org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration',
+                'org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration',
+                'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration',
+                'org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration',
+        ]
+    }
+
+    def "match handles mixed array of included and excluded auto-configurations"() {
+        given:
+        String[] autoConfigs = [
+                'org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+                'org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration',
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration',
+                'org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration',
+        ] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then:
+        results[0]  // DataSource — included
+        !results[1] // SecurityAutoConfiguration — excluded
+        results[2]  // Jackson — included
+        !results[3] // SecurityFilterAutoConfiguration — excluded
+        results[4]  // DispatcherServlet — included
+    }
+
+    def "match handles empty array"() {
+        given:
+        String[] autoConfigs = [] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then:
+        results.length == 0
+    }
+
+    def "match handles null metadata parameter gracefully"() {
+        given: 'autoConfigurationMetadata is null (not used by this filter)'
+        String[] autoConfigs = [
+                'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration',
+        ] as String[]
+
+        when:
+        boolean[] results = excluder.match(autoConfigs, null)
+
+        then: 'still works correctly'
+        !results[0]
+    }
+
+    def "getExcludedAutoConfigurations returns all 7 known conflicting classes"() {
+        when:
+        Set<String> excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
+
+        then:
+        excluded.size() == 7
+        excluded.contains('org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration')
+        excluded.contains('org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration')
+        excluded.contains('org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration')
+        excluded.contains('org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration')
+        excluded.contains('org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration')
+        excluded.contains('org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration')
+        excluded.contains('org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration')
+    }
+
+    def "getExcludedAutoConfigurations returns unmodifiable set"() {
+        when:
+        Set<String> excluded = SecurityAutoConfigurationExcluder.excludedAutoConfigurations
+        excluded.add('some.new.AutoConfiguration')
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "spring.factories registers the filter correctly"() {
+        when: 'enumerating all spring.factories resources on the classpath'
+        Enumeration<URL> resources = getClass().getClassLoader().getResources('META-INF/spring.factories')
+        List<String> allContents = Collections.list(resources).collect { it.text }
+
+        then: 'at least one spring.factories exists'
+        !allContents.isEmpty()
+
+        and: 'one of them registers SecurityAutoConfigurationExcluder as an AutoConfigurationImportFilter'
+        allContents.any { String content ->
+            content.contains('org.springframework.boot.autoconfigure.AutoConfigurationImportFilter') &&
+                content.contains('grails.plugin.springsecurity.SecurityAutoConfigurationExcluder')
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `SecurityAutoConfigurationExcluder` implementing `AutoConfigurationImportFilter` to automatically exclude 7 Spring Boot security auto-configuration classes that conflict with the Grails Spring Security plugin. This eliminates the manual `spring.autoconfigure.exclude` entries that every Grails 7 user currently must add to `application.yml`.

## Feature Description

The plugin [README](https://github.com/apache/grails-spring-security/blob/7.0.x/README.md#L53-L66) documents that Grails 7 requires 7 manual `spring.autoconfigure.exclude` entries:

```yaml
spring:
  autoconfigure:
    exclude:
      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
      - org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration
      - org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
      - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
      - org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration
      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
      - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
```

These exclusions are **always required** — not conditional or environment-specific. This boilerplate is easy to miss, hard to debug when forgotten, and should be handled automatically by the plugin.

## Implementation

**Approach**: `AutoConfigurationImportFilter` SPI (stable since Spring Boot 1.5.0, used in 3.x)

### Why `AutoConfigurationImportFilter` over alternatives

| Approach | Drawback |
|----------|----------|
| `EnvironmentPostProcessor` | `spring.autoconfigure.exclude` is a `List` — property sources cannot merge lists reliably ([Spring Boot #41669](https://github.com/spring-projects/spring-boot/issues/41669)). User's own exclusions would be overwritten. |
| `@EnableAutoConfiguration(exclude=...)` on plugin class | Plugin uses `@Grails` annotation, can't also use `@EnableAutoConfiguration` |
| Documentation-only (current approach) | Every user must copy 7 YAML lines; easy to miss |
| **`AutoConfigurationImportFilter`** | **✓ Runs before bytecode is loaded (faster)**<br>**✓ Opt-out via `excludeSpringSecurityAutoConfiguration: false`**<br>**✓ No property merging issues**<br>**✓ Used by established libraries (Redis OM Spring, TCC Transaction)** |

### Files Changed

| File | Change |
|------|--------|
| `SecurityAutoConfigurationExcluder.groovy` | **NEW** — `AutoConfigurationImportFilter` implementation that returns `false` for the 7 conflicting auto-configurations |
| `META-INF/spring.factories` | **NEW** — Registers the filter via SPI (filters still use `spring.factories` in Spring Boot 3.x, not `.imports`) |
| `build.gradle` | Added `compileOnly 'org.springframework.boot:spring-boot-autoconfigure'` — always available at runtime in any Grails app |
| `SecurityAutoConfigurationExcluderSpec.groovy` | **NEW** — 18 Spock tests covering all exclusions, preservation of non-security configs, mixed arrays, edge cases, and `spring.factories` registration |

### Test Coverage (18 tests, all pass)

- 7 data-driven tests: each excluded auto-configuration is filtered out
- 5 data-driven tests: non-security auto-configurations pass through
- 1 test: mixed array of included/excluded classes
- 1 test: empty array
- 1 test: null metadata parameter
- 1 test: all 7 known classes present in the exclusion set
- 1 test: exclusion set is unmodifiable
- 1 test: `spring.factories` registration is correct

### Backward Compatibility

- Users who already have manual exclusions in their `application.yml` are unaffected — the filter and manual exclusions are independent mechanisms
- No behavioral change for existing functionality
- `spring-boot-autoconfigure` is added as `compileOnly` only — no new runtime dependency (it's always already present via Spring Boot starter)

## Example Application

https://github.com/jamesfredley/grails-spring-security-autoconfig-exclusion

A minimal Grails 7.0.7 app with spring-security configured (User/Role/UserRole domains, annotation-based security) that intentionally does NOT include the manual exclusions. The `/bugDemo/index` endpoint shows which auto-configuration classes are on the classpath and which beans are registered.

## Environment Information

- **Grails**: 7.0.7
- **Spring Boot**: 3.5.10
- **Groovy**: 4.0.30
- **JDK**: 17

## Version

7.0.x

## Opt-Out

Users can disable the automatic exclusion by setting the following property in `application.yml`:

```yaml
grails:
  plugin:
    springsecurity:
      excludeSpringSecurityAutoConfiguration: false
```

This allows Spring Boot's security auto-configurations to run normally, for users who want to override or use Spring Boot's security setup directly. The filter implements `EnvironmentAware` to read this property during the auto-configuration discovery phase.