### PR TITLE
Fix ehcache jakarta classifier missing from published POM

### DIFF
--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -40,6 +40,15 @@ extensions.configure(GrailsPublishExtension) {
         url = 'https://apache.org/'
     }
     it.developers = project.property('pomDevelopers') as Map<String, String>
+    it.pomCustomization = { xml ->
+        xml.asNode().dependencies?.dependency?.findAll {
+            it.groupId.text() == 'org.ehcache' && it.artifactId.text() == 'ehcache'
+        }?.each {
+            if (!it.classifier) {
+                it.appendNode('classifier', 'jakarta')
+            }
+        }
+    }
 }
 
 afterEvaluate {
@@ -52,18 +61,6 @@ afterEvaluate {
         }
     }
     if (project.plugins.hasPlugin("maven-publish")) {
-        publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
-            publication.pom.withXml {
-                asNode().dependencies?.dependency?.findAll {
-                    it.groupId.text() == 'org.ehcache' && it.artifactId.text() == 'ehcache'
-                }?.each {
-                    if (!it.classifier) {
-                        it.appendNode('classifier', 'jakarta')
-                    }
-                }
-            }
-        }
-
         def checksumTask = tasks.register("publishedChecksums", Checksum)
         checksumTask.configure { Checksum check ->
             check.checksumAlgorithm = Checksum.Algorithm.SHA512

--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -52,6 +52,18 @@ afterEvaluate {
         }
     }
     if (project.plugins.hasPlugin("maven-publish")) {
+        publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
+            publication.pom.withXml {
+                asNode().dependencies?.dependency?.findAll {
+                    it.groupId.text() == 'org.ehcache' && it.artifactId.text() == 'ehcache'
+                }?.each {
+                    if (!it.classifier) {
+                        it.appendNode('classifier', 'jakarta')
+                    }
+                }
+            }
+        }
+
         def checksumTask = tasks.register("publishedChecksums", Checksum)
         checksumTask.configure { Checksum check ->
             check.checksumAlgorithm = Checksum.Algorithm.SHA512


### PR DESCRIPTION
## Summary

- Add `<classifier>jakarta</classifier>` to the ehcache dependency in published POMs via `pom.withXml` customization
- The existing `requireCapability('org.ehcache:ehcache-jakarta')` already works for Gradle consumers via `.module` metadata, but the POM lacked the classifier

## Problem

The published POM for `grails-spring-security` 7.0.1 declares:

```xml
<dependency>
  <groupId>org.ehcache</groupId>
  <artifactId>ehcache</artifactId>
  <scope>runtime</scope>
  <version>3.10.9</version>
  <!-- no classifier! -->
</dependency>
```

This causes `NoClassDefFoundError: javax/xml/bind/JAXBException` for consumers that resolve through the POM (Maven users, older Gradle, or Gradle with module metadata disabled).

## Fix

The `.module` metadata already correctly declares `requestedCapabilities` for `ehcache-jakarta`. This PR adds a `pom.withXml` block to also inject the `jakarta` classifier into the generated POM, so both resolution paths work:

- **Gradle consumers** (module metadata) - `requestedCapabilities` resolves jakarta variant ✅ (already working)
- **Maven/POM consumers** - `<classifier>jakarta</classifier>` resolves jakarta variant ✅ (this fix)

## Verification

Generated POM now contains:
```xml
<groupId>org.ehcache</groupId>
<artifactId>ehcache</artifactId>
<scope>runtime</scope>
<version>3.10.9</version>
<classifier>jakarta</classifier>
```

Fixes #1208
Related: #1191