### PR TITLE
Bump Java baseline from 17 to 21 for Grails 8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: liberica
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
@@ -64,7 +64,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: liberica
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
@@ -90,7 +90,7 @@ jobs:
       - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: liberica
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: liberica
-          java-version: 17
+          java-version: 21
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GRAILS_PUBLISH_RELEASE: true
   JAVA_DISTRIBUTION: liberica
-  JAVA_VERSION: 17.0.17 # this must be a specific version for reproducible builds, keep it synced with .sdkmanrc
+  JAVA_VERSION: 21.0.10 # this must be a specific version for reproducible builds, keep it synced with .sdkmanrc
   PROJECT_DESC: > 
     Apache Grails Spring Security adds production-ready
     authentication and authorization to Apache Grails applications.

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
-java=17.0.17-librca
+java=21.0.10-librca
 gradle=8.14.4
 # This is here to support the test app generation in the *rest projects
 grails=7.0.7

--- a/etc/bin/Dockerfile
+++ b/etc/bin/Dockerfile
@@ -16,7 +16,7 @@
 # for testing in a container that is similar to the github action linux build environment
 # run this from the root of the project
 # `docker build -t grails:testing -f etc/bin/Dockerfile . && docker run -it --rm -v $(pwd):/home/groovy/project grails:testing bash`
-FROM bellsoft/liberica-openjdk-debian:17.0.17
+FROM bellsoft/liberica-openjdk-debian:21.0.10
 
 USER root
 RUN apt-get update && apt-get install -y curl unzip coreutils libdigest-sha-perl gpg vim sudo psmisc locales groovy rsync

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 #
 projectVersion=8.0.0-SNAPSHOT
 grailsVersion=8.0.0-SNAPSHOT
-javaVersion=17
+javaVersion=21
 
 unboundidLdapSdkVersion=7.0.3
 apacheDsVersion=1.5.4


### PR DESCRIPTION
## Summary

Fixes the failing CI and RAT Report workflows on the `8.0.x` branch (e.g. https://github.com/apache/grails-spring-security/actions/runs/25003047902 ) by aligning the Java baseline with the Grails 8 / Spring Boot 4 / Spring Framework 7 requirement of Java 21.

## Root cause

`buildSrc` resolves `grails-gradle-bom:8.0.0-SNAPSHOT`, which now pulls Gradle plugins (`cloud.wondrify:asset-pipeline-gradle`, `org.apache.grails:grails-gradle-plugins`, `org.apache.grails.gradle:grails-publish`) compiled with Gradle module metadata that requires a JVM runtime of at least 21. Building under Java 17 fails during `:buildSrc:compileGroovy` with:

> Could not resolve cloud.wondrify:asset-pipeline-gradle.
>    > Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.

This breaks both `rat.yml` (the run cited in the issue) and `gradle.yml` (CI) on every push/PR against `8.0.x`.

## Changes

- `.github/workflows/gradle.yml`: `java-version: 17` -> `21` in all three jobs (`coreTests`, `functionalTests`, `publish`)
- `.github/workflows/rat.yml`: `java-version: 17` -> `21`
- `.github/workflows/release.yml`: `JAVA_VERSION: 17.0.17` -> `21.0.10`
- `gradle.properties`: `javaVersion=17` -> `21` (drives `compileJava.options.release` via `gradle/java-config.gradle`, so produced bytecode now targets 21)
- `.sdkmanrc`: `java=17.0.17-librca` -> `21.0.10-librca` (kept in sync with `release.yml` `JAVA_VERSION` per the comment in that file)
- `etc/bin/Dockerfile`: `bellsoft/liberica-openjdk-debian:17.0.17` -> `21.0.10`

## Verification of the Liberica 21.0.10 pin

- SDKMAN: `21.0.10-librca` is published in the SDKMAN Liberica catalog.
- Docker Hub: `bellsoft/liberica-openjdk-debian:21.0.10` exists for both `amd64` and `arm64`.

## Scope notes

- This PR targets `8.0.x` only. `7.0.x` still resolves released `grails-gradle-bom:7.0.7` artifacts that work on Java 17, so it is not affected.
- `docs/src/docs/whatsNew.adoc` and `upgrading7x.adoc` still mention "Java 17 baseline" because they describe Grails 7 history. Updating user-facing Grails 8 docs to call out the new Java 21 baseline is left to a follow-up so this PR stays a focused build/CI fix.