### PR TITLE
Add AGENTS.md with security-model link for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Agent Guide for grails-spring-security
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository. It points them at the
+human-authored references they should consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md) → [THREAT_MODEL.md](./THREAT_MODEL.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the linked
+`THREAT_MODEL.md` for the project's threat model — in-scope / out-of-scope
+declarations, security properties claimed and disclaimed, and known
+non-findings — before reporting issues.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds an `AGENTS.md` so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → THREAT_MODEL.md` chain. `SECURITY.md` and `THREAT_MODEL.md` already exist on this branch; the repo just has no `AGENTS.md` for the chain to start from. This PR adds only that file — no model content changes.

Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting. Such scans refuse to run if the model isn't mechanically discoverable by that path. Discoverability is the one hard gate; everything else is suggestion.

Questions / pushback welcome — happy to adjust the file to match house style.
